### PR TITLE
Adding projects for a stylecop runner

### DIFF
--- a/Testing.sln
+++ b/Testing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.21708.0
+VisualStudioVersion = 14.0.21719.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5525B6EA-8BBB-4437-BD09-419AE380BBA8}"
 EndProject
@@ -12,6 +12,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Testing", "src\Microsoft.AspNet.Testing\Microsoft.AspNet.Testing.kproj", "{09BE5203-8042-4338-9713-E44169342E72}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Sample.Tests", "test\Sample.Tests\Sample.Tests.kproj", "{25D18D0B-119C-4AB4-BCA6-AC06179335FA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KCop.Runner", "src\StyleCop.KRunner\KCop.Runner.csproj", "{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "StyleCop.KRules", "src\StyleCop.KRules\StyleCop.KRules.kproj", "{657EB507-EE7A-451F-90A4-196F6FCD66E5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +35,14 @@ Global
 		{25D18D0B-119C-4AB4-BCA6-AC06179335FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{25D18D0B-119C-4AB4-BCA6-AC06179335FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{25D18D0B-119C-4AB4-BCA6-AC06179335FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{657EB507-EE7A-451F-90A4-196F6FCD66E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{657EB507-EE7A-451F-90A4-196F6FCD66E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{657EB507-EE7A-451F-90A4-196F6FCD66E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{657EB507-EE7A-451F-90A4-196F6FCD66E5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -39,5 +51,7 @@ Global
 		{F003F228-2AE2-4E9D-877B-93EB773B7061} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
 		{09BE5203-8042-4338-9713-E44169342E72} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
 		{25D18D0B-119C-4AB4-BCA6-AC06179335FA} = {09F799F3-E521-466F-B155-B89E2746C8C9}
+		{62BE2FA4-6B9D-4296-9178-5FC2F66372AB} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
+		{657EB507-EE7A-451F-90A4-196F6FCD66E5} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
 	EndGlobalSection
 EndGlobal

--- a/src/StyleCop.KRules/StyleCop.KRules.kproj
+++ b/src/StyleCop.KRules/StyleCop.KRules.kproj
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>657eb507-ee7a-451f-90a4-196f6fcd66e5</ProjectGuid>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Console'">
+    <DebuggerFlavor>ConsoleDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(OutputType) == 'Web'">
+    <DebuggerFlavor>WebDebugger</DebuggerFlavor>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Content Include="project.json" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/StyleCop.KRules/project.json
+++ b/src/StyleCop.KRules/project.json
@@ -1,0 +1,12 @@
+﻿{
+    "version": "0.1-alpha-*",
+    "dependencies": {
+        "StyleCop":  "4.7.10.0"
+    },
+    "configurations" : {
+        "net45" : { 
+            "dependencies": {
+            }
+        }
+    }
+}

--- a/src/StyleCop.KRunner/KCop.Runner.csproj
+++ b/src/StyleCop.KRunner/KCop.Runner.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{62BE2FA4-6B9D-4296-9178-5FC2F66372AB}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>StyleCop.KRunner</RootNamespace>
+    <AssemblyName>StyleCop.KRunner</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <BaseIntermediateOutputPath>obj/net45</BaseIntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\net45</OutputPath>
+    <DefineConstants>DEBUG;TRACE;NET45;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\net45</OutputPath>
+    <DefineConstants>TRACE;NET45;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="mscorlib" />
+    <Reference Include="StyleCop, Version=4.7.10.0, Culture=neutral, PublicKeyToken=f904653c63bc2738, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\StyleCop.4.7.10.0\lib\StyleCop.dll</HintPath>
+    </Reference>
+    <Reference Include="StyleCop.CSharp">
+      <HintPath>..\..\packages\StyleCop.4.7.10.0\lib\StyleCop.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="StyleCop.CSharp.Rules">
+      <HintPath>..\..\packages\StyleCop.4.7.10.0\lib\StyleCop.CSharp.Rules.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/StyleCop.KRunner/Program.cs
+++ b/src/StyleCop.KRunner/Program.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Framework;
+
+namespace StyleCop.KRunner
+{
+    public class Program
+    {
+        private static readonly List<Violation> _violations = new List<Violation>();
+
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("StyleCop.KRunner - A StyleCop commandline runner");
+
+            if (args.Length == 0)
+            {
+                Console.WriteLine("Usage:");
+                Console.WriteLine("\tStyleCop.KRunner <path/to/project.json>");
+                Console.WriteLine();
+                return;
+            }
+
+            var projectFile = args[0];
+            if (!File.Exists(projectFile))
+            {
+                Console.WriteLine("File '{0}' does not exist.", Path.GetFullPath(projectFile));
+                return;
+            }
+
+            var runner = new StyleCopConsole(
+                settings: null, 
+                writeResultsCache: 
+                false, 
+                outputFile: null, 
+                addInPaths: null, 
+                loadFromDefaultPath: true); // Loads rules next to StyleCop.dll in the file system.
+
+            var projectDirectory = Path.GetDirectoryName(projectFile);
+
+            // It's OK if the settings file is null.
+            var settingsFile = FindSettingsFile(projectDirectory);
+
+            var project = new CodeProject(0, projectDirectory, new Configuration(null));
+            foreach (var file in Directory.EnumerateFiles(projectDirectory, "*.cs", SearchOption.AllDirectories))
+            {
+                runner.Core.Environment.AddSourceCode(project, file, context: null);
+            }
+
+            try
+            {
+                runner.OutputGenerated += Runner_OutputGenerated;
+                runner.ViolationEncountered += Runner_ViolationEncountered;
+
+                if (settingsFile == null)
+                {
+                    runner.Core.Analyze(new CodeProject[] { project });
+                }
+                else
+                {
+                    runner.Core.Analyze(new CodeProject[] { project }, settingsFile);
+                }
+            }
+            finally
+            {
+                runner.OutputGenerated -= Runner_OutputGenerated;
+                runner.ViolationEncountered -= Runner_ViolationEncountered;
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("{0} errors found.", _violations.Count);
+            Console.WriteLine();
+        }
+
+        // Performs an ascending directory search starting at the project directory
+        private static string FindSettingsFile(string projectDirectory)
+        {
+            var current = new DirectoryInfo(projectDirectory);
+            var root = current.Root;
+
+            do
+            {
+                var settingsFile = Path.Combine(current.FullName, "Settings.StyleCop");
+                if (File.Exists(settingsFile))
+                {
+                    return settingsFile;
+                }
+            }
+            while ((current = current.Parent) != null);
+
+            return null;
+        }
+
+        private static void Runner_ViolationEncountered(object sender, ViolationEventArgs e)
+        {
+            Console.WriteLine("{0}: {1} Line {2} - {3}", e.Violation.Rule.CheckId, e.SourceCode.Path, e.LineNumber, e.Message);
+
+            _violations.Add(e.Violation);
+        }
+
+        private static void Runner_OutputGenerated(object sender, OutputEventArgs e)
+        {
+            // There will be a bunch of message like "processing file Bleh.cs" with low importance,
+            // we're intentionally excluding those.
+            if (e.Importance != MessageImportance.Low)
+            {
+                Console.WriteLine(e.Output);
+            }
+        }
+    }
+}

--- a/src/StyleCop.KRunner/packages.config
+++ b/src/StyleCop.KRunner/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="StyleCop" version="4.7.10.0" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
- Runner is a console.exe because stylecop won't work on K10
- This means we have to manually package it, unless someone knows of a better solution
- Rules project is an empty placeholder for now
- Next change will port our 'header' rule
