### PR TITLE
Reflect the test framework using TestFrameworkAttribute

### DIFF
--- a/src/Xunit.KRunner/project.json
+++ b/src/Xunit.KRunner/project.json
@@ -2,6 +2,7 @@
   "version": "1.0.0-*",
   "dependencies": {
     "Microsoft.Framework.Runtime.Interfaces": "1.0.0-*",
+    "xunit.abstractions": "2.0.0-aspnet-*",
     "xunit.assert": "2.0.0-aspnet-*",
     "xunit.execution": "2.0.0-aspnet-*"
   },


### PR DESCRIPTION
Allows overriding the test framework using an assembly attribute.
Necessary to add custom discoverers and executors.
