### PR TITLE
Fix for testing #38 - VS cannot run [Theory] tests with multiple

### DIFF
--- a/src/Xunit.KRunner/CommandLine.cs
+++ b/src/Xunit.KRunner/CommandLine.cs
@@ -94,33 +94,7 @@ namespace Xunit.ConsoleClient
                         throw new ArgumentException("missing argument for --test");
                     }
 
-                    var insideParens = false;
-                    var start = 0;
-
-                    for (var i = 0; i < option.Value.Length; i++)
-                    {
-                        var c = option.Value[i];
-
-                        if (!insideParens && 
-                            (c == ';' || c == ','))
-                        {
-                            Tests.Add(option.Value.Substring(start, i - start));
-                            start = i + 1;
-                        }
-                        else if (c == '(')
-                        {
-                            insideParens = true;
-                        }
-                        else if (c == ')')
-                        {
-                            insideParens = false;
-                        }
-                    }
-
-                    if (start < option.Value.Length)
-                    {
-                        Tests.Add(option.Value.Substring(start));
-                    }
+                    Tests.AddRange(option.Value.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries));
                 }
                 else if (optionName == "-teamcity")
                 {

--- a/src/Xunit.KRunner/DesignTime/TestCaseExtensions.cs
+++ b/src/Xunit.KRunner/DesignTime/TestCaseExtensions.cs
@@ -13,7 +13,7 @@ namespace Xunit.KRunner
             var test = new Test()
             {
                 DisplayName = testCase.DisplayName,
-                FullyQualifiedName = testCase.DisplayName,
+                FullyQualifiedName = testCase.UniqueID,
             };
 
             if (testCase.SourceInformation != null)

--- a/src/Xunit.KRunner/Program.cs
+++ b/src/Xunit.KRunner/Program.cs
@@ -245,9 +245,9 @@ namespace Xunit.KRunner
         }
 
         // Performs fuzzy matching for test names specified at the commandline.
-        // - test name specified at the command line might by a test uniqueId (guid) OR
+        // - test name specified at the command line might be a test uniqueId (guid) OR
         // - test name might be a full test display name (including parameters)
-        // - test might be the test class + method name
+        // - test name might be the test class + method name
         private bool IsTestNameMatch(ITestCase test, IList<string> testNames)
         {
             foreach (var testName in testNames)

--- a/src/Xunit.KRunner/Program.cs
+++ b/src/Xunit.KRunner/Program.cs
@@ -3,13 +3,14 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.Runtime;
+using Microsoft.Framework.TestAdapter;
+using Xunit.Abstractions;
 using Xunit.ConsoleClient;
 using Xunit.Sdk;
-using Xunit.Abstractions;
-using Microsoft.Framework.TestAdapter;
 #if !NET45
 using System.Diagnostics;
 #endif
@@ -205,9 +206,9 @@ namespace Xunit.KRunner
                 var resultsVisitor = CreateVisitor(consoleLock, options);
 
                 var tests = discoveryVisitor.TestCases;
-                if (options.Tests != null && options.Tests.Length > 0)
+                if (options.Tests != null && options.Tests.Count > 0)
                 {
-                    tests = tests.Where(t => options.Tests.Contains(t.DisplayName)).ToList();
+                    tests = tests.Where(t => IsTestNameMatch(t, options.Tests)).ToList();
                 }
 
                 executor.RunTests(tests, resultsVisitor, executionOptions);
@@ -241,6 +242,37 @@ namespace Xunit.KRunner
             var testFrameworkType = Reflector.GetType(ctorArgs[1], ctorArgs[0]);
             var framework = Activator.CreateInstance(testFrameworkType) as ITestFramework;
             return framework ?? new XunitTestFramework();
+        }
+
+        // Performs fuzzy matching for test names specified at the commandline.
+        // - test name specified at the command line might by a test uniqueId (guid) OR
+        // - test name might be a full test display name (including parameters)
+        // - test might be the test class + method name
+        private bool IsTestNameMatch(ITestCase test, IList<string> testNames)
+        {
+            foreach (var testName in testNames)
+            {
+                if (string.Equals(testName, test.UniqueID, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+                else if (string.Equals(testName, test.DisplayName, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+                else if (!testName.Contains('(') && test.DisplayName.Contains('('))
+                {
+                    // No parameters in testName, and parameters in the displayname, it might be
+                    // the 'short' display name (without parameters).
+                    var shortName = test.DisplayName.Substring(0, test.DisplayName.IndexOf('('));
+                    if (string.Equals(testName, shortName, StringComparison.Ordinal))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/test/Sample.Tests/SampleTest.cs
+++ b/test/Sample.Tests/SampleTest.cs
@@ -12,5 +12,21 @@ namespace Sample.Tests
         {
             Assert.True(true);
         }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        public void TheoryTest1(int x)
+        {
+        }
+
+        [Theory]
+        [InlineData(1, "Hi")]
+        [InlineData(2, "Hi")]
+        [InlineData(3, "Hi")]
+        public void TheoryTest2(int x, string s)
+        {
+        }
     }
 }


### PR DESCRIPTION
parameters

The problem here is the way we're using for VS to communicate with the
test runner via the commandline isn't very well suited for the problem
space.

If VS wants to run `MyTestClass.Test1` and `MyTestClass.Test2` then it will
build a commandline like:

`k test --design-time --test MyTestClass.Test1,MyTestClass.Test2`

The runner knows to split the argument on `,` or `;` and then we have the test
names to run. This is problematic when the test name contains either of
these characters.

VS is taking a change to pass the test 'fully-qualified-name' instead of display name. That will look like:
`k test --design-time --test <guid1>,<guid2>`

We'll do a full solution in the next phase of the test adapter.