### PR TITLE
Added support for acks from the host

### DIFF
--- a/test/Microsoft.Framework.TestHost.Tests/TestHostTest.cs
+++ b/test/Microsoft.Framework.TestHost.Tests/TestHostTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Framework.TestHost
             Assert.Equal("TestDiscovery.Response", host.Output[host.Output.Count - 1].MessageType);
         }
 
-        [Fact(Skip = "diagnosting failures")]
+        [Fact]
         public async Task RunTest_All()
         {
             // Arrange
@@ -79,7 +79,7 @@ namespace Microsoft.Framework.TestHost
             Assert.Equal("TestExecution.Response", host.Output[host.Output.Count - 1].MessageType);
         }
 
-        [Fact(Skip = "diagnosting failures")]
+        [Fact]
         public async Task RunTest_ByDisplayName()
         {
             // Arrange
@@ -102,7 +102,7 @@ namespace Microsoft.Framework.TestHost
             Assert.Equal("TestExecution.Response", host.Output[host.Output.Count - 1].MessageType);
         }
 
-        [Fact(Skip = "diagnosting failures")]
+        [Fact]
         public async Task RunTest_ByDisplayName_Short()
         {
             // Arrange
@@ -124,7 +124,7 @@ namespace Microsoft.Framework.TestHost
             Assert.Equal("TestExecution.Response", host.Output[host.Output.Count - 1].MessageType);
         }
 
-        [Fact(Skip = "diagnosting failures")]
+        [Fact]
         public async Task RunTest_ByUniqueName()
         {
             // Arrange


### PR DESCRIPTION
- The framework host should wait for an ack from the client
  before quitting.
- Reenabled the tests
