### PR TITLE
Conditional run attributes

### DIFF
--- a/src/Microsoft.AspNet.Testing/WindowsApis.cs
+++ b/src/Microsoft.AspNet.Testing/WindowsApis.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if ASPNETCORE50
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNet.Testing
+{
+    internal static class WindowsApis
+    {
+        public static Version OSVersion
+        {
+            get
+            {
+                uint dwVersion = GetVersion();
+
+                int major = (int)(dwVersion & 0xFF);
+                int minor = (int)((dwVersion >> 8) & 0xFF);
+
+                return new Version(major, minor);
+            }
+        }
+
+        [DllImport("kernel32.dll")]
+        private static extern uint GetVersion();
+    }
+}
+
+#endif

--- a/src/Microsoft.AspNet.Testing/project.json
+++ b/src/Microsoft.AspNet.Testing/project.json
@@ -2,7 +2,8 @@
     "version": "1.0.0-*",
     "dependencies": {
         "xunit.assert": "2.0.0-aspnet-*",
-        "xunit.core": "2.0.0-aspnet-*"
+        "xunit.core": "2.0.0-aspnet-*",
+        "xunit.execution": "2.0.0-aspnet-*",
     },
     "frameworks": {
         "aspnet50": {
@@ -15,6 +16,7 @@
         "aspnetcore50": {
             "dependencies": {
                 "System.Runtime": "4.0.20-beta-*",
+                "System.Runtime.InteropServices": "4.0.20-beta-",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*",
                 "System.Reflection": "4.0.10-beta-*",

--- a/src/Microsoft.AspNet.Testing/xunit/ConditionalAttributeDiscoverer.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/ConditionalAttributeDiscoverer.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    internal class ConditionalAttributeDiscoverer : IXunitTestCaseDiscoverer
+    {
+        public IEnumerable<IXunitTestCase> Discover(ITestCollection testCollection, IAssemblyInfo assembly, ITypeInfo testClass, IMethodInfo testMethod, IAttributeInfo factAttribute)
+        {
+            var skipReason = EvaluateSkipConditions(testMethod);
+            var wrapperAttributeInfo = new SkipReasonAttributeInfo(skipReason, factAttribute);
+
+            IXunitTestCaseDiscoverer innerDiscoverer;
+            if (testMethod.GetCustomAttributes(typeof(TheoryAttribute)).Any())
+            {
+                innerDiscoverer = new TheoryDiscoverer();
+            }
+            else
+            {
+                innerDiscoverer = new FactDiscoverer();
+            }
+
+            var res = innerDiscoverer.Discover(testCollection, assembly, testClass, testMethod, wrapperAttributeInfo);
+            return res;
+        }
+
+        private string EvaluateSkipConditions(IMethodInfo testMethod)
+        {
+            var conditionAttributes = testMethod
+                .GetCustomAttributes(typeof(ITestCondition))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => attributeInfo.Attribute);
+
+            foreach (ITestCondition condition in conditionAttributes)
+            {
+                if (!condition.IsMet)
+                {
+                    return condition.SkipReason;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/ConditionalFactAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/ConditionalFactAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("Microsoft.AspNet.Testing.xunit.ConditionalAttributeDiscoverer", "Microsoft.AspNet.Testing")]
+    public class ConditionalFactAttribute : FactAttribute
+    {
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/ConditionalTheoryAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/ConditionalTheoryAttribute.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    [XunitTestCaseDiscoverer("Microsoft.AspNet.Testing.xunit.ConditionalAttributeDiscoverer", "Microsoft.AspNet.Testing")]
+    public class ConditionalTheoryAttribute : TheoryAttribute
+    {
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/FrameworkConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/FrameworkConditionAttribute.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class FrameworkSkipConditionAttribute : Attribute, ITestCondition
+    {
+        private RuntimeFrameworks _excludedFrameworks;
+
+        public FrameworkSkipConditionAttribute(RuntimeFrameworks excludedFrameworks)
+        {
+            _excludedFrameworks = excludedFrameworks;
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                return CanRunOnThisFramework(_excludedFrameworks);
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                return "Test cannot run on this runtime framework.";
+            }
+        }
+
+        private static bool CanRunOnThisFramework(RuntimeFrameworks excludedFrameworks)
+        {
+            if (excludedFrameworks == RuntimeFrameworks.None)
+            {
+                return true;
+            }
+
+            if (excludedFrameworks.HasFlag(RuntimeFrameworks.Mono) &&
+                  TestPlatformHelper.IsMono)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/ITestCondition.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/ITestCondition.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    public interface ITestCondition
+    {
+        bool IsMet { get; }
+
+        string SkipReason { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class OSSkipConditionAttribute : Attribute, ITestCondition
+    {
+        private OperatingSystems _excludedOS;
+
+        public OSSkipConditionAttribute(OperatingSystems excludedOperatingSystems)
+        {
+            _excludedOS = excludedOperatingSystems;
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                return CanRunOnThisOS(_excludedOS);
+            }
+        }
+
+        public string SkipReason
+        {
+            get
+            {
+                return "Test cannot run on this operating system.";
+            }
+        }
+
+        private static bool CanRunOnThisOS(OperatingSystems excludedOperatingSystems)
+        {
+            if (excludedOperatingSystems == OperatingSystems.None)
+            {
+                return true;
+            }
+
+            bool isWindows = false;
+#if ASPNETCORE50
+            Version osVersion = WindowsApis.OSVersion;
+
+            // No platform check because it is always Windows
+            isWindows = true;
+#else
+            Version osVersion = Environment.OSVersion.Version;
+
+            switch (Environment.OSVersion.Platform)
+            {
+            case PlatformID.Win32NT:
+                isWindows = true;
+                break;
+            case PlatformID.Unix:
+                if (excludedOperatingSystems.HasFlag(OperatingSystems.Unix))
+                {
+                    return false;
+                }
+                break;
+            }
+#endif
+
+            if (isWindows)
+            {
+                if (osVersion.Major == 6)
+                {
+                    if (osVersion.Minor == 1 &&
+                        (excludedOperatingSystems.HasFlag(OperatingSystems.Win7) ||
+                        excludedOperatingSystems.HasFlag(OperatingSystems.Win2008R2)))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/OperatingSystems.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/OperatingSystems.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [Flags]
+    public enum OperatingSystems
+    {
+        None = 0,
+        Win7 = 1 << 0,
+        Win2008R2 = 1 << 1,
+        Unix = 1 << 2,
+
+        Win7And2008R2 = Win7 | Win2008R2,
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/RuntimeFrameworks.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/RuntimeFrameworks.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [Flags]
+    public enum RuntimeFrameworks
+    {
+        None = 0,
+        Mono = 1 << 0,
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/SkipReasonAttributeInfo.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/SkipReasonAttributeInfo.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    internal class SkipReasonAttributeInfo : IAttributeInfo
+    {
+        private IAttributeInfo _wrappedAttribute;
+        private string _skipReason;
+
+        public SkipReasonAttributeInfo(string skipReason, IAttributeInfo wrappedAttribute)
+        {
+            _wrappedAttribute = wrappedAttribute;
+            _skipReason = skipReason;
+        }
+
+        public TValue GetNamedArgument<TValue>(string argumentName)
+        {
+            var argumentValue = _wrappedAttribute.GetNamedArgument<TValue>(argumentName);
+
+            // Override the skip reason if we have one and there 
+            // was not already one specified by the user
+            if (_skipReason != null &&
+                typeof(TValue) == typeof(string) &&
+                argumentName == "Skip")
+            {
+                string stringValue = (string)(object)argumentValue;
+                if (stringValue == null)
+                {
+                    return (TValue)(object)_skipReason;
+                }
+            }
+
+            return argumentValue;
+        }
+
+        public IEnumerable<object> GetConstructorArguments()
+        {
+            return _wrappedAttribute.GetConstructorArguments();
+        }
+
+        public IEnumerable<IAttributeInfo> GetCustomAttributes(string assemblyQualifiedAttributeTypeName)
+        {
+            return _wrappedAttribute.GetCustomAttributes(assemblyQualifiedAttributeTypeName);
+        }
+    }
+}


### PR DESCRIPTION
Added two attributes that allow tests to be ignored on particular operating systems or runtime frameworks. We need this for the downlevel CI runs.

There is a little bit of code duplication because of how xunit implemented `Theory` and `Fact`...

Example usage:

```
[ConditionalFact(
    ExcludedFrameworks = RuntimeFrameworks.Mono, 
    ExcludedOperatingSystems = OperatingSystems.Windows7And2008R2)]
public void MyTest()
{
    ...
```

@bricelam @Tratcher 
