### PR TITLE
Adding System.Diagnostics.TraceSource to fix build errors

### DIFF
--- a/src/Microsoft.Framework.TestHost/project.json
+++ b/src/Microsoft.Framework.TestHost/project.json
@@ -20,7 +20,8 @@
         "aspnetcore50": {
             "dependencies": {
                 "System.Console": "4.0.0-beta-*",
-                "System.Diagnostics.Process": "4.0.0-beta-*"
+                "System.Diagnostics.Process": "4.0.0-beta-*",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-*"
             }
         }
     }


### PR DESCRIPTION
AspnetCore50 builds fail with a "The name 'Trace' does not exist in the current context" error.

@bricelam @pranavkm 