### PR TITLE
Add testing UI for TestHost

### DIFF
--- a/Testing.sln
+++ b/Testing.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22613.0
+VisualStudioVersion = 14.0.22727.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5525B6EA-8BBB-4437-BD09-419AE380BBA8}"
 EndProject
@@ -24,6 +24,10 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Logging.Testing", "src\Microsoft.Framework.Logging.Testing\Microsoft.Framework.Logging.Testing.xproj", "{379AA56B-E1A6-4133-9A45-7F70385F39FB}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Framework.Logging.Testing.Tests", "test\Microsoft.Framework.Logging.Testing.Tests\Microsoft.Framework.Logging.Testing.Tests.xproj", "{6FA3EFAE-2DBC-4532-A5A0-C2EBD8DD672F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{57A90243-F8A5-4115-BA05-A1CEEBD8A5CD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Framework.TestHost.UI", "tools\Microsoft.Framework.TestHost.UI\Microsoft.Framework.TestHost.UI.csproj", "{2A16C1BE-8777-473A-A581-02E10D82C49D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -67,6 +71,10 @@ Global
 		{6FA3EFAE-2DBC-4532-A5A0-C2EBD8DD672F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FA3EFAE-2DBC-4532-A5A0-C2EBD8DD672F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FA3EFAE-2DBC-4532-A5A0-C2EBD8DD672F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -81,5 +89,6 @@ Global
 		{25D18D0C-119C-4AB4-BCA6-AC06179335FA} = {09F799F3-E521-466F-B155-B89E2746C8C9}
 		{379AA56B-E1A6-4133-9A45-7F70385F39FB} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
 		{6FA3EFAE-2DBC-4532-A5A0-C2EBD8DD672F} = {09F799F3-E521-466F-B155-B89E2746C8C9}
+		{2A16C1BE-8777-473A-A581-02E10D82C49D} = {57A90243-F8A5-4115-BA05-A1CEEBD8A5CD}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Framework.TestHost/Program.cs
+++ b/src/Microsoft.Framework.TestHost/Program.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Framework.TestHost
             var portOption = application.Option("--port", "Port number to listen for a connection.", CommandOptionType.SingleValue);
             var projectOption = application.Option("--project", "Path to a project file.", CommandOptionType.SingleValue);
 
+            var debugOption = application.Option("--debug", "Launch the debugger", CommandOptionType.NoValue);
+
             // Show help information if no subcommand was specified
             application.OnExecute(() =>
             {
@@ -43,6 +45,11 @@ namespace Microsoft.Framework.TestHost
 
                 command.OnExecute(async () =>
                 {
+                    if (debugOption.HasValue())
+                    {
+                        Debugger.Launch();
+                    }
+
                     var projectPath = projectOption.Value() ?? env.ApplicationBasePath;
                     var port = int.Parse(portOption.Value());
 
@@ -60,6 +67,11 @@ namespace Microsoft.Framework.TestHost
 
                 command.OnExecute(async () =>
                 {
+                    if (debugOption.HasValue())
+                    {
+                        Debugger.Launch();
+                    }
+
                     var projectPath = projectOption.Value() ?? env.ApplicationBasePath;
                     var port = int.Parse(portOption.Value());
 
@@ -82,7 +94,7 @@ namespace Microsoft.Framework.TestHost
 
                 string testCommand = null;
                 Project project = null;
-                if (Project.TryGetProject(projectPath, out project))
+                if (Project.TryGetProject(projectPath, out project, diagnostics: null))
                 {
                     project.Commands.TryGetValue("test", out testCommand);
                 }
@@ -142,7 +154,7 @@ namespace Microsoft.Framework.TestHost
 
                 string testCommand = null;
                 Project project = null;
-                if (Project.TryGetProject(projectPath, out project))
+                if (Project.TryGetProject(projectPath, out project, diagnostics: null))
                 {
                     project.Commands.TryGetValue("test", out testCommand);
                 }

--- a/test/Microsoft.Framework.Logging.Testing.Tests/Microsoft.Framework.Logging.Testing.Tests.xproj
+++ b/test/Microsoft.Framework.Logging.Testing.Tests/Microsoft.Framework.Logging.Testing.Tests.xproj
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Sample.Tests/Sample.Tests.xproj
+++ b/test/Sample.Tests/Sample.Tests.xproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
@@ -13,5 +13,8 @@
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/tools/Microsoft.Framework.TestHost.UI/App.xaml
+++ b/tools/Microsoft.Framework.TestHost.UI/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="Microsoft.Framework.TestHost.UI.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Microsoft.Framework.TestHost.UI"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/tools/Microsoft.Framework.TestHost.UI/App.xaml.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/App.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    /// <summary>
+    /// Interaction logic for App.xaml
+    /// </summary>
+    public partial class App : Application
+    {
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/DNX.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/DNX.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public static class DNX
+    {
+        public static string FindDnx()
+        {
+            var process = new Process();
+            process.StartInfo = new ProcessStartInfo()
+            {
+                FileName = "cmd",
+                Arguments = "/c where dnx",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+            };
+
+            process.Start();
+            process.WaitForExit();
+            return process.StandardOutput.ReadToEnd().TrimEnd('\r', '\n');
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml
+++ b/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml
@@ -1,0 +1,199 @@
+﻿<Window
+  x:Class="Microsoft.Framework.TestHost.UI.MainWindow"
+  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:local="clr-namespace:Microsoft.Framework.TestHost.UI"
+  mc:Ignorable="d"
+  Title="TestHost Diagnostics"
+  Height="600"
+  Width="800"
+  Background="LightGray">
+  <Window.Resources>
+    <Style
+      x:Key="{x:Type TextBox}"
+      TargetType="{x:Type TextBox}">
+      <Setter
+        Property="Padding"
+        Value="10 5 10 5" />
+      <Setter
+        Property="Margin"
+        Value="5" />
+    </Style>
+    <Style
+      x:Key="{x:Type ListBox}"
+      TargetType="{x:Type ListBox}">
+      <Setter
+        Property="Margin"
+        Value="5" />
+    </Style>
+    <Style
+      x:Key="{x:Type Button}"
+      TargetType="{x:Type Button}">
+      <Setter
+        Property="Padding"
+        Value="10 5 10 5" />
+      <Setter
+        Property="Margin"
+        Value="5" />
+    </Style>
+    <Style
+      x:Key="{x:Type Label}"
+      TargetType="{x:Type Label}">
+      <Setter
+        Property="Padding"
+        Value="10 5 10 5" />
+      <Setter
+        Property="Margin"
+        Value="5" />
+    </Style>
+  </Window.Resources>
+  <Grid>
+    <Grid.RowDefinitions>
+      <RowDefinition
+        Height="Auto" />
+      <RowDefinition
+        Height="*" />
+      <RowDefinition
+        Height="5" />
+      <RowDefinition
+        MinHeight="200" />
+    </Grid.RowDefinitions>
+    <Border
+      Grid.Row="0"
+      BorderBrush="Black"
+      BorderThickness="0 0 0 1">
+      <Grid
+        Margin="5">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition
+            Width="Auto" />
+          <ColumnDefinition
+            Width="*" />
+          <ColumnDefinition
+            Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition
+            Height="Auto" />
+          <RowDefinition
+            Height="Auto" />
+        </Grid.RowDefinitions>
+        <Label
+          Content="Choose project file:"
+          Grid.Column="0"
+          Grid.Row="0" />
+        <TextBox
+          Grid.Column="1"
+          Grid.Row="0"
+          Text="{Binding SelectedProject}"
+          IsReadOnly="True"
+          VerticalContentAlignment="Center" />
+        <Button
+          Command="{Binding SelectProject}"
+          Content="..."
+          Grid.Column="2"
+          Grid.Row="0"
+          Width="30" />
+        <Label
+          Content="Choose DNX:"
+          Grid.Column="0"
+          Grid.Row="1" />
+        <TextBox
+          Grid.Column="1"
+          Grid.Row="1"
+          Text="{Binding DNX}"
+          IsReadOnly="True"
+          VerticalContentAlignment="Center" />
+        <Button
+          Command="{Binding SelectDNX}"
+          Content="..."
+          Grid.Column="2"
+          Grid.Row="1"
+          Width="30" />
+      </Grid>
+    </Border>
+    <Grid
+      Grid.Row="1">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition
+          Width="Auto" />
+        <ColumnDefinition
+          Width="*" />
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition
+          Height="Auto" />
+        <RowDefinition
+          Height="*" />
+      </Grid.RowDefinitions>
+      <StackPanel
+        IsEnabled="{Binding IsReady}"
+        Orientation="Vertical"
+        Grid.Column="0"
+        Grid.Row="0">
+        <StackPanel
+          Orientation="Horizontal"
+          Visibility="Collapsed">
+          <Button
+            Content="Start" />
+          <Button
+            Content="Stop" />
+          <Label
+            Content="Process:" />
+          <TextBox
+            Text="{Binding ProcessId}"
+            Width="50"
+            IsReadOnly="True" />
+        </StackPanel>
+        <StackPanel>
+          <Button
+            Content="Discover Tests"
+            Command="{Binding DiscoverTests}" />
+        </StackPanel>
+        <StackPanel>
+          <Button
+            Content="Run All Tests"
+            Command="{Binding RunAllTests}" />
+        </StackPanel>
+        <StackPanel
+          Visibility="Collapsed">
+          <Button
+            Content="Run Selected Tests"
+            Command="{Binding RunSelectedTests}" />
+        </StackPanel>
+      </StackPanel>
+      <Grid
+        Grid.Column="0"
+        Grid.Row="1">
+        <ListBox />
+      </Grid>
+      <Grid
+        Grid.Column="1"
+        Grid.Row="0"
+        Grid.RowSpan="2">
+        <ScrollViewer>
+          <TextBox
+            x:Name="_messageBuffer"
+            IsReadOnly="True"
+            TextWrapping="NoWrap" />
+        </ScrollViewer>
+      </Grid>
+    </Grid>
+    <GridSplitter
+      Grid.Row="2"
+      HorizontalAlignment="Stretch"
+      Height="5"
+      Background="LightGray"/>
+    <Grid
+      Grid.Row="3">
+      <ScrollViewer>
+        <TextBox
+          x:Name="_consoleBuffer"
+          IsReadOnly="True"
+          TextWrapping="Wrap" />
+      </ScrollViewer>
+    </Grid>
+  </Grid>
+</Window>

--- a/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml.cs
@@ -1,0 +1,28 @@
+﻿
+using System.Windows;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            DataContext = new MainWindowViewModel(this);
+            DataContext.DNX = DNX.FindDnx();
+        }
+
+        public new MainWindowViewModel DataContext
+        {
+            get
+            {
+                return (MainWindowViewModel)base.DataContext;
+            }
+            set
+            {
+                base.DataContext = value;
+            }
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/MainWindowViewModel.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/MainWindowViewModel.cs
@@ -1,0 +1,265 @@
+﻿
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using Microsoft.Win32;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public class MainWindowViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private readonly Window _window;
+        private readonly TextBox _console;
+        private readonly TextBox _messages;
+
+        private string _dnx;
+        private bool _isRunning;
+        private int _processId;
+        private string _selectedProject;
+
+        public MainWindowViewModel(Window window)
+        {
+            _window = window;
+            _console = (TextBox)window.FindName("_consoleBuffer");
+            _messages = (TextBox)window.FindName("_messageBuffer");
+
+            DiscoverTests = new RelayCommand<object>(ExecuteDiscoverTests, CanExecuteDiscoverTests);
+            SelectDNX = new RelayCommand<object>(ExecuteSelectDNX, CanExecuteSelectDNX);
+            SelectProject = new RelayCommand<object>(ExecuteSelectProject, CanExecuteSelectProject);
+            StartTestHost = new RelayCommand<object>(ExecuteStartTestHost, CanExecuteStartTestHost);
+            RunAllTests = new RelayCommand<object>(ExecuteRunAllTests, CanExecuteRunAllTests);
+            RunSelectedTests = new RelayCommand<object>(ExecuteRunSelectedTests, CanExecuteRunSelectedTests);
+        }
+
+        public string DNX
+        {
+            get
+            {
+                return _dnx;
+            }
+            set
+            {
+                _dnx = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsReady));
+            }
+        }
+
+        public bool IsReady
+        {
+            get
+            {
+                return !string.IsNullOrWhiteSpace(SelectedProject) && !string.IsNullOrWhiteSpace(DNX);
+            }
+        }
+
+        public bool IsRunning
+        {
+            get
+            {
+                return _isRunning;
+            }
+            set
+            {
+                _isRunning = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int ProcessId
+        {
+            get
+            {
+                return _processId;
+            }
+            set
+            {
+                _processId = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public string SelectedProject
+        {
+            get
+            {
+                return _selectedProject;
+            }
+            set
+            {
+                _selectedProject = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsReady));
+            }
+        }
+
+        public ICommand SelectDNX { get; }
+
+        private bool CanExecuteSelectDNX(object _)
+        {
+            return !IsRunning;
+        }
+
+        private void ExecuteSelectDNX(object _)
+        {
+            var dialog = new OpenFileDialog()
+            {
+                CheckFileExists = true,
+                DefaultExt = ".exe",
+                Filter = "dnx Executable (dnx.exe)|dnx.exe",
+                InitialDirectory = DNX == null ? null : Path.GetDirectoryName(DNX),
+                Title = "DNX"
+            };
+
+            if (dialog.ShowDialog(_window) == true)
+            {
+                DNX = dialog.FileName;
+            }
+        }
+
+        public ICommand SelectProject { get; }
+
+        private bool CanExecuteSelectProject(object _)
+        {
+            return !IsRunning;
+        }
+
+        private void ExecuteSelectProject(object _)
+        {
+            var dialog = new OpenFileDialog()
+            {
+                CheckFileExists = true,
+                DefaultExt = ".json",
+                Filter = "Test Project Files (project.json)|project.json",
+                InitialDirectory = SelectedProject == null ? null : Path.GetDirectoryName(SelectedProject),
+                Title = "Select Test Project"
+            };
+
+            if (dialog.ShowDialog(_window) == true)
+            {
+                SelectedProject = dialog.FileName;
+            }
+        }
+
+        public ICommand StartTestHost { get; }
+
+        private bool CanExecuteStartTestHost(object _)
+        {
+            return !IsRunning && IsReady;
+        }
+
+        private void ExecuteStartTestHost(object _)
+        {
+
+        }
+
+        public ICommand DiscoverTests { get; }
+
+        private bool CanExecuteDiscoverTests(object _)
+        {
+            return !IsRunning && IsReady;
+        }
+
+        private async void ExecuteDiscoverTests(object _)
+        {
+            var wrapper = new TestHostWrapper(DNX);
+            _console.Text = string.Empty;
+            _messages.Text = string.Empty;
+            wrapper.ConsoleOutputReceived += TestHost_ConsoleOutputReceived;
+            wrapper.MessageReceived += TestHost_MessageReceived;
+
+            try
+            {
+                IsRunning = true;
+                await wrapper.RunListAsync(SelectedProject);
+            }
+            catch (Exception ex)
+            {
+                ShowErrorDialog(ex);
+            }
+            finally
+            {
+                wrapper.MessageReceived -= TestHost_MessageReceived;
+                wrapper.ConsoleOutputReceived -= TestHost_ConsoleOutputReceived;
+                IsRunning = false;
+            }
+        }
+
+        public ICommand RunAllTests { get; }
+
+        private bool CanExecuteRunAllTests(object _)
+        {
+            return !IsRunning && IsReady;
+        }
+
+        private async void ExecuteRunAllTests(object _)
+        {
+            var wrapper = new TestHostWrapper(DNX);
+            _console.Text = string.Empty;
+            _messages.Text = string.Empty;
+            wrapper.ConsoleOutputReceived += TestHost_ConsoleOutputReceived;
+            wrapper.MessageReceived += TestHost_MessageReceived;
+
+            try
+            {
+                IsRunning = true;    
+                await wrapper.RunTestsAsync(SelectedProject);
+            }
+            catch (Exception ex)
+            {
+                ShowErrorDialog(ex);
+            }
+            finally
+            {
+                wrapper.MessageReceived -= TestHost_MessageReceived;
+                wrapper.ConsoleOutputReceived -= TestHost_ConsoleOutputReceived;
+                IsRunning = false;
+            }
+        }
+
+        public ICommand RunSelectedTests { get; }
+
+        private bool CanExecuteRunSelectedTests(object _)
+        {
+            return !IsRunning && IsReady;
+        }
+
+        private async void ExecuteRunSelectedTests(object _)
+        {
+            await Task.Delay(1);
+        }
+
+        private void TestHost_ConsoleOutputReceived(object sender, DataReceivedEventArgs e)
+        {
+            _console.Dispatcher.BeginInvoke(new Action<string>(_console.AppendText), e.Data + Environment.NewLine);
+        }
+
+        private void TestHost_MessageReceived(object sender, Message e)
+        {
+            _messages.Dispatcher.BeginInvoke(new Action<string>(_messages.AppendText), e.ToString() + Environment.NewLine);
+        }
+
+        private void ShowErrorDialog(Exception ex)
+        {
+            MessageBox.Show(_window, ex.ToString(), "Error", MessageBoxButton.OK, MessageBoxImage.Error, MessageBoxResult.OK);
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            var handler = PropertyChanged;
+            if (handler != null)
+            {
+                handler(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/Message.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/Message.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public class Message
+    {
+        public string MessageType { get; set; }
+
+        public JToken Payload { get; set; }
+
+        public override string ToString()
+        {
+            return "(" + MessageType + ") -> " + (Payload == null ? "null" : Payload.ToString(Formatting.Indented));
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/Microsoft.Framework.TestHost.UI.csproj
+++ b/tools/Microsoft.Framework.TestHost.UI/Microsoft.Framework.TestHost.UI.csproj
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2A16C1BE-8777-473A-A581-02E10D82C49D}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.Framework.TestHost.UI</RootNamespace>
+    <AssemblyName>Microsoft.Framework.TestHost.UI</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1-beta1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Include="DNX.cs" />
+    <Compile Include="Message.cs" />
+    <Compile Include="RelayCommand.cs" />
+    <Compile Include="TestHostWrapper.cs" />
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MainWindowViewModel.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <None Include="packages.config" />
+    <AppDesigner Include="Properties\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tools/Microsoft.Framework.TestHost.UI/Properties/AssemblyInfo.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/Properties/AssemblyInfo.cs
@@ -1,0 +1,55 @@
+﻿using System.Reflection;
+using System.Resources;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.Framework.TestHost.UI")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.Framework.TestHost.UI")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+//In order to begin building localizable applications, set 
+//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
+//inside a <PropertyGroup>.  For example, if you are using US english
+//in your source files, set the <UICulture> to en-US.  Then uncomment
+//the NeutralResourceLanguage attribute below.  Update the "en-US" in
+//the line below to match the UICulture setting in the project file.
+
+//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
+
+
+[assembly: ThemeInfo(
+    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
+                                     //(used if a resource is not found in the page, 
+                                     // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
+                                              //(used if a resource is not found in the page, 
+                                              // app, or any theme specific resource dictionaries)
+)]
+
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tools/Microsoft.Framework.TestHost.UI/RelayCommand.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/RelayCommand.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public class RelayCommand<T> : ICommand
+    {
+        private readonly Action<T> _execute = null;
+        private readonly Predicate<T> _canExecute = null;
+
+        public RelayCommand(Action<T> execute)
+            : this(execute, null)
+        {
+        }
+
+        public RelayCommand(Action<T> execute, Predicate<T> canExecute)
+        {
+            _execute = execute;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return _canExecute == null ? true : _canExecute((T)parameter);
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+
+        public void Execute(object parameter)
+        {
+            _execute((T)parameter);
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/TestHostWrapper.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/TestHostWrapper.cs
@@ -1,0 +1,206 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Microsoft.Framework.TestHost.UI
+{
+    public class TestHostWrapper
+    {
+        public DataReceivedEventHandler ConsoleOutputReceived;
+
+        public EventHandler<Message> MessageReceived;
+
+        public TestHostWrapper(string dnx)
+        {
+            DNX = dnx;
+        }
+
+        private string DNX { get; }
+
+        public async Task<int> RunListAsync(string project)
+        {
+            var port = FindFreePort();
+
+            var arguments = new List<string>();
+
+            arguments.Add("--port");
+            arguments.Add(port.ToString());
+
+            arguments.Add("--project");
+            arguments.Add(project);
+
+            //arguments.Add("--debug");
+
+            arguments.Add("list");
+
+            // This will block until the test host opens the port
+            var listener = Task.Run(() => GetMessage(port, "TestDiscovery.Response"));
+
+            var process = RunDNX(project, arguments);
+            process.WaitForExit();
+
+            await listener;
+
+            return process.ExitCode;
+        }
+
+        public async Task<int> RunTestsAsync(string project, params string[] tests)
+        {
+            var port = FindFreePort();
+
+            var arguments = new List<string>();
+
+            arguments.Add("--port");
+            arguments.Add(port.ToString());
+
+            arguments.Add("--project");
+            arguments.Add(project);
+
+            arguments.Add("run");
+
+            foreach (var test in tests)
+            {
+                arguments.Add("--test");
+                arguments.Add(test);
+            }
+
+            // This will block until the test host opens the port
+            var listener = Task.Run(() => GetMessage(port, "TestExecution.Response"));
+
+            var process = RunDNX(project, arguments);
+            process.WaitForExit();
+
+            await listener;
+
+            return process.ExitCode;
+        }
+
+        private Process RunDNX(string project, IEnumerable<string> args)
+        {
+            if (project.EndsWith("project.json", StringComparison.OrdinalIgnoreCase))
+            {
+                project = Path.GetDirectoryName(project);
+            }
+
+            var allArgs = ". Microsoft.Framework.TestHost " + string.Join(" ", args.Select(Quote));
+            var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                Arguments = allArgs,
+                CreateNoWindow = true,
+                FileName = DNX,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                WorkingDirectory = project,
+            };
+
+            process.OutputDataReceived += Process_OutputDataReceived;
+            process.ErrorDataReceived += Process_OutputDataReceived;
+
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            return process;
+        }
+
+        private void OnMessageReceived(object sender, Message e)
+        {
+            var handler = MessageReceived;
+            if (handler != null)
+            {
+                handler(sender, e);
+            }
+        }
+
+        private void Process_OutputDataReceived(object sender, DataReceivedEventArgs e)
+        {
+            var handler = ConsoleOutputReceived;
+            if (handler != null && e.Data != null)
+            {
+                handler(sender, e);
+            }
+        }
+
+        private static string Quote(string arg)
+        {
+            return "\"" + arg + "\"";
+        }
+
+        private void GetMessage(int port, string terminalMessageType)
+        {
+            try
+            {
+                using (var client = new TcpClient())
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        try
+                        {
+                            client.Connect(new IPEndPoint(IPAddress.Loopback, port));
+                            break;
+                        }
+                        catch (SocketException)
+                        {
+                            Thread.Sleep(100);
+                        }
+                    }
+
+                    if (!client.Connected)
+                    {
+                        throw new Exception("Unable to connect.");
+                    }
+
+                    var stream = client.GetStream();
+                    using (var reader = new BinaryReader(stream))
+                    {
+                        while (true)
+                        {
+                            var message = JsonConvert.DeserializeObject<Message>(reader.ReadString());
+                            OnMessageReceived(this, message);
+
+                            if (string.Equals(message.MessageType, terminalMessageType))
+                            {
+                                var writer = new BinaryWriter(stream);
+                                writer.Write(JsonConvert.SerializeObject(new Message
+                                {
+                                    MessageType = "TestHost.Acknowledge"
+                                }));
+
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Thrown when the socket is closed by the test process.
+            }
+            catch (EndOfStreamException)
+            {
+                // Thrown if nothing was written by the test process.
+            }
+        }
+
+        private int FindFreePort()
+        {
+            using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+                return ((IPEndPoint)socket.LocalEndPoint).Port;
+            }
+        }
+    }
+}

--- a/tools/Microsoft.Framework.TestHost.UI/packages.config
+++ b/tools/Microsoft.Framework.TestHost.UI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="7.0.1-beta1" targetFramework="net45" userInstalled="true" />
+</packages>


### PR DESCRIPTION
Adds a diagnostic UI for using TestHost to discover/run tests. It will capture all console output and messages sent from the TestHost.

For now the only things that are supported are 'discover tests' and 'run all tests'. Will be adding more functionality in parallel with fixes/feature bringups.

![image](https://cloud.githubusercontent.com/assets/1430011/7010625/976bbdfc-dc57-11e4-8e34-1873224d1bf3.png)
