### PR TITLE
Added a custom assert for comparing log values

### DIFF
--- a/src/Microsoft.Framework.Logging.Testing/LogValuesAssert.cs
+++ b/src/Microsoft.Framework.Logging.Testing/LogValuesAssert.cs
@@ -1,0 +1,75 @@
+﻿// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.Internal;
+using Xunit.Sdk;
+
+namespace Microsoft.Framework.Logging.Testing
+{
+    public static class LogValuesAssert
+    {
+        /// <summary>
+        /// Asserts that the given key and value are present in the actual values.
+        /// </summary>
+        /// <param name="key">The key of the item to be found.</param>
+        /// <param name="value">The value of the item to be found.</param>
+        /// <param name="actualValues">The actual values.</param>
+        public static void Contains(
+            string key,
+            object value,
+            IEnumerable<KeyValuePair<string, object>> actualValues)
+        {
+            Contains(new[] { new KeyValuePair<string, object>(key, value) }, actualValues);
+        }
+
+        /// <summary>
+        /// Asserts that all the expected values are present in the actual values by ignoring
+        /// the order of values.
+        /// </summary>
+        /// <param name="expectedValues">Expected subset of values</param>
+        /// <param name="actualValues">Actual set of values</param>
+        /// <param name="comparer">
+        /// An <see cref="IEqualityComparer{T}"/> to compare the values. 
+        /// In case no comparer is provided, a default comparer is used.
+        /// </param>
+        public static void Contains(
+            [NotNull] IEnumerable<KeyValuePair<string, object>> expectedValues,
+            [NotNull] IEnumerable<KeyValuePair<string, object>> actualValues)
+        {
+            var comparer = new LogValueComparer();
+
+            foreach (var expectedPair in expectedValues)
+            {
+                if (!actualValues.Contains(expectedPair, comparer))
+                {
+                    throw new EqualException(
+                        expected: GetString(expectedValues),
+                        actual: GetString(actualValues));
+                }
+            }
+        }
+
+        private static string GetString(IEnumerable<KeyValuePair<string, object>> logValues)
+        {
+            return string.Join(",", logValues.Select(kvp => $"[{kvp.Key} {kvp.Value}]"));
+        }
+
+        private class LogValueComparer : IEqualityComparer<KeyValuePair<string, object>>
+        {
+            public bool Equals(KeyValuePair<string, object> x, KeyValuePair<string, object> y)
+            {
+                return string.Equals(x.Key, y.Key) && object.Equals(x.Value, y.Value);
+            }
+
+            public int GetHashCode(KeyValuePair<string, object> obj)
+            {
+                // We are never going to put this KeyValuePair in a hash table,
+                // so this is ok.
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.Logging.Testing/project.json
+++ b/src/Microsoft.Framework.Logging.Testing/project.json
@@ -1,11 +1,27 @@
 {
     "version": "1.0.0-*",
     "dependencies": {
-        "Microsoft.Framework.Logging.Interfaces": "1.0.0-*"
+        "Microsoft.Framework.Logging.Interfaces": "1.0.0-*",
+        "Microsoft.Framework.NotNullAttribute.Internal": { "version": "1.0.0-*", "type": "build" }
     },
     "frameworks": {
-        "net45": { },
-        "dnx451": { },
-        "dnxcore50": { }
+        "net45": {
+            "dependencies": {
+                "xunit.assert": "2.0.0-rc3-*"
+            },
+            "frameworkAssemblies": {
+                "System.Runtime": "4.0.0.0"
+            }
+        },
+        "dnx451": {
+            "dependencies": {
+                "xunit.runner.aspnet": "2.0.0-aspnet-*"
+            }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "xunit.runner.aspnet": "2.0.0-aspnet-*"
+            }
+        }
     }
 }

--- a/test/Microsoft.Framework.Logging.Testing.Tests/LogValuesAssertTest.cs
+++ b/test/Microsoft.Framework.Logging.Testing.Tests/LogValuesAssertTest.cs
@@ -1,0 +1,222 @@
+﻿// Copyright(c) Microsoft Open Technologies, Inc.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Microsoft.Framework.Logging.Testing.Tests
+{
+    public class LogValuesAssertTest
+    {
+        public static TheoryData<
+            IEnumerable<KeyValuePair<string, object>>,
+            IEnumerable<KeyValuePair<string, object>>> ExpectedValues_SubsetOf_ActualValuesData
+        {
+            get
+            {
+                return new TheoryData<
+                    IEnumerable<KeyValuePair<string, object>>,
+                    IEnumerable<KeyValuePair<string, object>>>()
+                {
+                    {
+                        new KeyValuePair<string,object>[] { },
+                        new KeyValuePair<string,object>[] { }
+                    },
+                    {
+                        // subset
+                        new KeyValuePair<string,object>[] { },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id")
+                        }
+                    },
+                    {
+                        // subset
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id")
+                        },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                            new KeyValuePair<string, object>("RouteConstraint", "Something")
+                        }
+                    },
+                    {
+                        // equal number of values
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id")
+                        },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ExpectedValues_SubsetOf_ActualValuesData))]
+        public void Asserts_Success_ExpectedValues_SubsetOf_ActualValues(
+            IEnumerable<KeyValuePair<string, object>> expectedValues,
+            IEnumerable<KeyValuePair<string, object>> actualValues)
+        {
+            // Act && Assert
+            LogValuesAssert.Contains(expectedValues, actualValues);
+        }
+
+        public static TheoryData<
+            IEnumerable<KeyValuePair<string, object>>,
+            IEnumerable<KeyValuePair<string, object>>> ExpectedValues_MoreThan_ActualValuesData
+        {
+            get
+            {
+                return new TheoryData<
+                    IEnumerable<KeyValuePair<string, object>>,
+                    IEnumerable<KeyValuePair<string, object>>>()
+                {
+                    {
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id")
+                        },
+                        new KeyValuePair<string,object>[] { }
+                    },
+                    {
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                            new KeyValuePair<string, object>("RouteConstraint", "Something")
+                        },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                            new KeyValuePair<string, object>("RouteKey", "id")
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(ExpectedValues_MoreThan_ActualValuesData))]
+        public void Asserts_Failure_ExpectedValues_MoreThan_ActualValues(
+            IEnumerable<KeyValuePair<string, object>> expectedValues,
+            IEnumerable<KeyValuePair<string, object>> actualValues)
+        {
+            // Act && Assert
+            var equalException = Assert.Throws<EqualException>(
+                () => LogValuesAssert.Contains(expectedValues, actualValues));
+
+            Assert.Equal(GetString(expectedValues), equalException.Expected);
+            Assert.Equal(GetString(actualValues), equalException.Actual);
+        }
+
+        [Fact]
+        public void Asserts_Success_IgnoringOrderOfItems()
+        {
+            // Arrange
+            var expectedLogValues = new[]
+            {
+                new KeyValuePair<string, object>("RouteConstraint", "Something"),
+                new KeyValuePair<string, object>("RouteValue", "Failure"),
+                new KeyValuePair<string, object>("RouteKey", "id")
+            };
+            var actualLogValues = new[]
+            {
+                new KeyValuePair<string, object>("RouteKey", "id"),
+                new KeyValuePair<string, object>("RouteConstraint", "Something"),
+                new KeyValuePair<string, object>("RouteValue", "Failure"),
+            };
+
+            // Act && Assert
+            LogValuesAssert.Contains(expectedLogValues, actualLogValues);
+        }
+
+        [Fact]
+        public void Asserts_Success_OnSpecifiedKeyAndValue()
+        {
+            // Arrange
+            var actualLogValues = new[]
+            {
+                new KeyValuePair<string, object>("RouteConstraint", "Something"),
+                new KeyValuePair<string, object>("RouteKey", "id"),
+                new KeyValuePair<string, object>("RouteValue", "Failure"),
+            };
+
+            // Act && Assert
+            LogValuesAssert.Contains("RouteKey", "id", actualLogValues);
+        }
+
+        public static TheoryData<
+            IEnumerable<KeyValuePair<string, object>>,
+            IEnumerable<KeyValuePair<string, object>>> CaseSensitivityComparisionData
+        {
+            get
+            {
+                return new TheoryData<
+                    IEnumerable<KeyValuePair<string, object>>,
+                    IEnumerable<KeyValuePair<string, object>>>()
+                {
+                    {
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                        },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("ROUTEKEY", "id"),
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                        }
+                    },
+                    {
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                            new KeyValuePair<string, object>("RouteValue", "Failure"),
+                        },
+                        new[]
+                        {
+                            new KeyValuePair<string, object>("RouteKey", "id"),
+                            new KeyValuePair<string, object>("RouteValue", "FAILURE"),
+                        }
+                    }
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(CaseSensitivityComparisionData))]
+        public void DefaultComparer_Performs_CaseSensitiveComparision(
+            IEnumerable<KeyValuePair<string, object>> expectedValues,
+            IEnumerable<KeyValuePair<string, object>> actualValues)
+        {
+            // Act && Assert
+            var equalException = Assert.Throws<EqualException>(
+                () => LogValuesAssert.Contains(expectedValues, actualValues));
+
+            Assert.Equal(GetString(expectedValues), equalException.Expected);
+            Assert.Equal(GetString(actualValues), equalException.Actual);
+        }
+
+        private string GetString(IEnumerable<KeyValuePair<string, object>> logValues)
+        {
+            return logValues == null ?
+                "Null" :
+                string.Join(",", logValues.Select(kvp => $"[{kvp.Key} {kvp.Value}]"));
+        }
+    }
+}


### PR DESCRIPTION
@rynowak 

Some notes
Even though Xunit supports comparing dictionaries, some reasons for this new assert:
- Xunit's dictionary comparison expects count of values to match. This is a problem as the actual list of values can contain more entries than the expected values. This is true with the case of `FormattedLogValues` which adds an additional item called `{OriginalFormat}`. We do not individual tests to also test this as its internal to the `FormattedLogValues` implementation.
- We only want to make sure that all the expected log values are present and not worry about the order of them.