### PR TITLE
Adding support for logging to TestHost

### DIFF
--- a/src/Microsoft.Framework.TestHost/Messages/LogMessage.cs
+++ b/src/Microsoft.Framework.TestHost/Messages/LogMessage.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.TestHost
+{
+    public class LogMessage
+    {
+        public string Name { get; set; }
+
+        public int EventId { get; set; }
+
+        public string Level { get; set; }
+
+        public string Message { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.TestHost/Program.cs
+++ b/src/Microsoft.Framework.TestHost/Program.cs
@@ -111,10 +111,10 @@ namespace Microsoft.Framework.TestHost
                     }
 
                     var args = new List<string>()
-                {
-                    "test",
-                    "--designtime"
-                };
+                    {
+                        "test",
+                        "--designtime"
+                    };
 
                     if (tests != null)
                     {
@@ -172,7 +172,6 @@ namespace Microsoft.Framework.TestHost
                     }
 
                     var args = new string[] { "test", "--list", "--designtime" };
-
 
                     var testServices = TestServices.CreateTestServices(_services, project, channel);
                     await ProjectCommand.Execute(testServices, project, args);

--- a/src/Microsoft.Framework.TestHost/TestAdapter/TestHostLoggerProvider.cs
+++ b/src/Microsoft.Framework.TestHost/TestAdapter/TestHostLoggerProvider.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.Logging;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Framework.TestHost
+{
+    public class TestHostLoggerProvider : ILoggerProvider
+    {
+        private readonly ReportingChannel _channel;
+
+        public TestHostLoggerProvider(ReportingChannel channel)
+        {
+            _channel = channel;
+        }
+
+        public ILogger CreateLogger(string name)
+        {
+            return new TestHostLogger(name, _channel);
+        }
+
+        private class TestHostLogger : ILogger
+        {
+            private readonly string _name;
+            private readonly ReportingChannel _channel;
+
+            public TestHostLogger(string name, ReportingChannel channel)
+            {
+                _name = name;
+                _channel = channel;
+            }
+
+            public IDisposable BeginScopeImpl(object state)
+            {
+                return null;
+            }
+
+            public bool IsEnabled(LogLevel logLevel)
+            {
+                // Don't filter - send everything to the server.
+                return true;
+            }
+
+            public void Log(
+                LogLevel logLevel,
+                int eventId,
+                object state,
+                Exception exception,
+                Func<object, Exception, string> formatter)
+            {
+                string message = null;
+                if (formatter != null)
+                {
+                    message = formatter(state, exception);
+                }
+                else if (state != null)
+                {
+                    message = state.ToString();
+                    if (exception != null)
+                    {
+                        message += Environment.NewLine + exception.ToString();
+                    }
+                }
+                else if (exception != null)
+                {
+                    message = exception.ToString();
+                }
+
+                if (string.IsNullOrEmpty(message))
+                {
+                    return;
+                }
+
+                _channel.Send(new Message()
+                {
+                    MessageType = "Log",
+                    Payload = JToken.FromObject(new LogMessage()
+                    {
+                        Name = _name,
+                        EventId = eventId,
+                        Level = logLevel.ToString(),
+                        Message = message,
+                    }),
+                });
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.TestHost/TestServices.cs
+++ b/src/Microsoft.Framework.TestHost/TestServices.cs
@@ -22,6 +22,10 @@ namespace Microsoft.Framework.TestHost
         {
             var services = new ServiceProvider(applicationServices);
 
+            var loggerFactory = new LoggerFactory();
+            loggerFactory.AddProvider(new TestHostLoggerProvider(channel));
+            services.Add(typeof(ILoggerFactory), loggerFactory);
+
             var libraryManager = applicationServices.GetRequiredService<ILibraryManager>();
             var export = libraryManager.GetLibraryExport(project.Name);
 
@@ -32,29 +36,12 @@ namespace Microsoft.Framework.TestHost
 
             services.Add(
                 typeof(ISourceInformationProvider),
-                new SourceInformationProvider(projectReference, new NullLogger()));
+                new SourceInformationProvider(projectReference, loggerFactory.CreateLogger<SourceInformationProvider>()));
 
             services.Add(typeof(ITestDiscoverySink), new TestDiscoverySink(channel));
             services.Add(typeof(ITestExecutionSink), new TestExecutionSink(channel));
 
             return services;
-        }
-
-        private class NullLogger : ILogger
-        {
-            public IDisposable BeginScopeImpl(object state)
-            {
-                return null;
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return false;
-            }
-
-            public void Log(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
-            {
-            }
         }
     }
 }

--- a/tools/Microsoft.Framework.TestHost.UI/MainWindowViewModel.cs
+++ b/tools/Microsoft.Framework.TestHost.UI/MainWindowViewModel.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Framework.TestHost.UI
                 CheckFileExists = true,
                 DefaultExt = ".exe",
                 Filter = "dnx Executable (dnx.exe)|dnx.exe",
-                InitialDirectory = DNX == null ? null : Path.GetDirectoryName(DNX),
+                InitialDirectory = string.IsNullOrEmpty(DNX) ? null : Path.GetDirectoryName(DNX),
                 Title = "DNX"
             };
 


### PR DESCRIPTION
This change adds a custom LoggerProvider to TestHost which will pass
messages back through the reporting channel for VS to receive.