### PR TITLE
Triggering TestHost with a message

### DIFF
--- a/src/Microsoft.Framework.TestHost/Messages/RunTestsMessage.cs
+++ b/src/Microsoft.Framework.TestHost/Messages/RunTestsMessage.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.TestHost
+{
+    public class RunTestsMessage
+    {
+        public List<string> Tests { get; set; }
+    }
+}

--- a/test/Microsoft.Framework.TestHost.Tests/TestHostTest.cs
+++ b/test/Microsoft.Framework.TestHost.Tests/TestHostTest.cs
@@ -30,10 +30,12 @@ namespace Microsoft.Framework.TestHost
         public async Task ListTest()
         {
             // Arrange
-            var host = new TestHostWrapper();
+            var host = new TestHostWrapper(_testProject);
+
+            await host.StartAsync();
 
             // Act
-            var result = await host.RunListAsync(_testProject);
+            var result = await host.ListTestsAsync();
 
             // Assert
             Assert.Equal(0, result);
@@ -53,10 +55,12 @@ namespace Microsoft.Framework.TestHost
         public async Task RunTest_All()
         {
             // Arrange
-            var host = new TestHostWrapper();
+            var host = new TestHostWrapper(_testProject);
+
+            await host.StartAsync();
 
             // Act
-            var result = await host.RunTestsAsync(_testProject);
+            var result = await host.RunTestsAsync();
 
             // Assert
             Assert.Equal(0, result);
@@ -83,9 +87,11 @@ namespace Microsoft.Framework.TestHost
         public async Task RunTest_ByUniqueName()
         {
             // Arrange
-            var host = new TestHostWrapper();
+            var host = new TestHostWrapper(_testProject);
 
-            await host.RunListAsync(_testProject);
+            await host.StartAsync();
+
+            await host.ListTestsAsync();
 
             var test = host.Output
                 .Where(m => m.MessageType == "TestDiscovery.TestFound")
@@ -93,6 +99,9 @@ namespace Microsoft.Framework.TestHost
                 .Payload.ToObject<Test>();
 
             host.Output.Clear();
+
+            host = new TestHostWrapper(_testProject);
+            await host.StartAsync();
 
             // Act
             var result = await host.RunTestsAsync(_testProject, test.FullyQualifiedName);

--- a/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml
+++ b/tools/Microsoft.Framework.TestHost.UI/MainWindow.xaml
@@ -66,6 +66,8 @@
         Height="5" />
       <RowDefinition
         MinHeight="200" />
+      <RowDefinition
+        Height="Auto"/>
     </Grid.RowDefinitions>
     <Border
       Grid.Row="0"
@@ -141,12 +143,13 @@
         Grid.Column="0"
         Grid.Row="0">
         <StackPanel
-          Orientation="Horizontal"
-          Visibility="Collapsed">
+          Orientation="Horizontal">
           <Button
-            Content="Start" />
+            Content="Start"
+            Command="{Binding StartTestHost}"/>
           <Button
-            Content="Stop" />
+            Content="Stop"
+            Command="{Binding StopTestHost}"/>
           <Label
             Content="Process:" />
           <TextBox
@@ -213,5 +216,12 @@
           TextWrapping="Wrap" />
       </ScrollViewer>
     </Grid>
+    <StatusBar
+      Grid.Row="4">
+      <StatusBarItem>
+        <Label 
+          Content="{Binding Status}" />
+      </StatusBarItem>
+    </StatusBar>
   </Grid>
 </Window>

--- a/tools/Microsoft.Framework.TestHost.UI/Microsoft.Framework.TestHost.UI.csproj
+++ b/tools/Microsoft.Framework.TestHost.UI/Microsoft.Framework.TestHost.UI.csproj
@@ -67,6 +67,9 @@
     <Compile Include="..\..\src\Microsoft.Framework.TestHost\Messages\Message.cs">
       <Link>Message.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\Microsoft.Framework.TestHost\Messages\RunTestsMessage.cs">
+      <Link>RunTestsMessage.cs</Link>
+    </Compile>
     <Compile Include="RelayCommand.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
This change will allow TestHost to execute a command (discover or execute)
based on a message instead of parsing the commandline. This will get us
out of trouble for the cases where a 'run all tests' results in a
commandline string that is too long.

Updates the UI and test code as well to use this.