### PR TITLE
Minimal fix for #117

### DIFF
--- a/src/Microsoft.Framework.TestHost/ProjectCommand.cs
+++ b/src/Microsoft.Framework.TestHost/ProjectCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Common.DependencyInjection;
@@ -29,6 +30,17 @@ namespace Microsoft.Framework.TestHost
                 (IAssemblyLoaderContainer)services.GetService(typeof(IAssemblyLoaderContainer)),
                 environment,
                 newServices);
+
+            var options = (IRuntimeOptions)services.GetService(typeof(IRuntimeOptions));
+            if (options.CompilationServerPort.HasValue)
+            {
+                args = new string[]
+                {
+                    "--port",
+                    options.CompilationServerPort.Value.ToString()
+                }
+                .Concat(args).ToArray();
+            }
 
             return await applicationHost.Main(args);
         }


### PR DESCRIPTION
This passes the port through to the ApplicationHost to avoid a problem
where the compiler has already decided to use DTH, but doesn't know the
port.

The more complete fix will be to eliminate the use of the ApplicationHost
code inside TestHost.