### PR TITLE
Target net46 in Microsoft.AspNet.Testing

### DIFF
--- a/src/Microsoft.AspNet.Testing/ExceptionAssertions.cs
+++ b/src/Microsoft.AspNet.Testing/ExceptionAssertions.cs
@@ -184,14 +184,18 @@ namespace Microsoft.AspNet.Testing
                 if (actualValue != null)
                 {
                     exceptionMessage += Environment.NewLine;
+#if !NET46
                     if (TestPlatformHelper.IsMono)
                     {
                         exceptionMessage += actualValue;
                     }
                     else
                     {
+#endif
                         exceptionMessage += String.Format(CultureReplacer.DefaultCulture, "Actual value was {0}.", actualValue);
+#if !NET46
                     }
+#endif
                 }
             }
 

--- a/src/Microsoft.AspNet.Testing/TestPlatformHelper.cs
+++ b/src/Microsoft.AspNet.Testing/TestPlatformHelper.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !NET46
+
 using System;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Infrastructure;
@@ -22,3 +24,5 @@ namespace Microsoft.AspNet.Testing
         internal static IRuntimeEnvironment RuntimeEnvironment { get { return _runtimeEnv.Value; } }
     }
 }
+
+#endif

--- a/src/Microsoft.AspNet.Testing/project.json
+++ b/src/Microsoft.AspNet.Testing/project.json
@@ -1,11 +1,22 @@
 {
     "version": "1.0.0-*",
-    "dependencies": {
-        "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
-        "xunit.runner.aspnet": "2.0.0-aspnet-*"
-    },
     "frameworks": {
+        "net46": {
+            "dependencies": {
+                "xunit.assert": "2.0.0-rc3-*",
+                "xunit.extensibility.execution": "2.0.0-rc3-*"
+            },
+            "frameworkAssemblies": {
+                "System.Reflection": { "version": "4.0.0.0", "type": "build" },
+                "System.Runtime": { "version": "4.0.0.0", "type": "build" },
+                "System.Threading.Tasks": { "version": "4.0.0.0", "type": "build" }
+            }
+        },
         "dnx451": {
+            "dependencies": {
+                "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
+                "xunit.runner.aspnet": "2.0.0-aspnet-*"
+            },
             "frameworkAssemblies": {
                 "System.Runtime": "",
                 "System.Reflection": "",
@@ -14,12 +25,14 @@
         },
         "dnxcore50": {
             "dependencies": {
+                "Microsoft.Framework.Runtime.Abstractions": "1.0.0-*",
                 "System.Runtime": "4.0.20-beta-*",
                 "System.Runtime.InteropServices": "4.0.20-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Threading.Tasks": "4.0.10-beta-*",
                 "System.Reflection": "4.0.10-beta-*",
-                "System.Threading.Thread": "4.0.0-beta-*"
+                "System.Threading.Thread": "4.0.0-beta-*",
+                "xunit.runner.aspnet": "2.0.0-aspnet-*"
             }
         }
     }

--- a/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !NET46
+
 using System;
 using Microsoft.Framework.Runtime;
 using Microsoft.Framework.Runtime.Infrastructure;
@@ -62,3 +64,5 @@ namespace Microsoft.AspNet.Testing.xunit
         }
     }
 }
+
+#endif

--- a/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !NET46
+
 using System;
 
 namespace Microsoft.AspNet.Testing.xunit
@@ -74,3 +76,5 @@ namespace Microsoft.AspNet.Testing.xunit
         }
     }
 }
+
+#endif


### PR DESCRIPTION
This is to support aspnet/EntityFramework#2321. (EF runs their tests outside of DNX too.)

/cc @dougbu, @divega 
