### PR TITLE
Follow up to fixing async symbol support

### DIFF
--- a/src/Microsoft.Dnx.TestAdapter/ISourceInformationProvider.cs
+++ b/src/Microsoft.Dnx.TestAdapter/ISourceInformationProvider.cs
@@ -1,10 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
+using Microsoft.Framework.Internal;
+
 namespace Microsoft.Dnx.TestAdapter
 {
     public interface ISourceInformationProvider
     {
-        SourceInformation GetSourceInformation(string className, string methodName);
+        SourceInformation GetSourceInformation([NotNull] MethodInfo method);
     }
 }

--- a/src/Microsoft.Dnx.TestAdapter/ITestDiscoverySink.cs
+++ b/src/Microsoft.Dnx.TestAdapter/ITestDiscoverySink.cs
@@ -1,10 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Framework.Internal;
+
 namespace Microsoft.Dnx.TestAdapter
 {
     public interface ITestDiscoverySink
     {
-        void SendTest(Test test);
+        void SendTest([NotNull] Test test);
     }
 }

--- a/src/Microsoft.Dnx.TestAdapter/ITestExecutionSink.cs
+++ b/src/Microsoft.Dnx.TestAdapter/ITestExecutionSink.cs
@@ -1,12 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Framework.Internal;
+
 namespace Microsoft.Dnx.TestAdapter
 {
     public interface ITestExecutionSink
     {
-        void RecordStart(Test test);
+        void RecordStart([NotNull] Test test);
 
-        void RecordResult(TestResult testResult);
+        void RecordResult([NotNull] TestResult testResult);
     }
 }

--- a/test/Microsoft.Dnx.TestHost.Tests/TestHostTest.cs
+++ b/test/Microsoft.Dnx.TestHost.Tests/TestHostTest.cs
@@ -53,14 +53,13 @@ namespace Microsoft.Dnx.TestHost
             var fullMessageDiagnostics = string.Format("Full output: \n{0}", string.Join("\n", host.Output));
             var testOutput = host.Output.Where(message => message.MessageType != "Log");
 
-            Assert.True(10 == testOutput.Count(), "Output count is not 8. \n" + fullMessageDiagnostics);
+            Assert.True(10 == testOutput.Count(), "Number of messages is not right. \n" + fullMessageDiagnostics);
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.True_is_true"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest1(x: 1)"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest1(x: 2)"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest1(x: 3)"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest2(x: 1, s: \"Hi\")"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest2(x: 2, s: \"Hi\")"));
-            Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest2(x: 3, s: \"Hi\")"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.TheoryTest2(x: 3, s: \"Hi\")"));
             Assert.Single(host.Output, m => TestFound(m, "SampleTest.SampleAsyncTest"));
             Assert.Single(host.Output, m => TestFound(m, "DerivedTest.ThisGetsInherited"));


### PR DESCRIPTION
Changing signature of ISourceInformationProvider to work with MethodInfo
instead.

Also cleaning up some little issues in unit tests and adding a few
[NotNull]s that were needed.