### PR TITLE
Get only the first line of there where command output because there might be multiple results

### DIFF
--- a/src/Microsoft.Dnx.TestHost.Client.Sources/DNX.cs
+++ b/src/Microsoft.Dnx.TestHost.Client.Sources/DNX.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Dnx.TestHost.Client
 
             process.Start();
             process.WaitForExit();
-            return process.StandardOutput.ReadToEnd().TrimEnd('\r', '\n');
+            // Get the first result only. Workaround for multiple results until IRuntimeEnvironment
+            // exposes the path to DNX
+            return process.StandardOutput.ReadLine().TrimEnd('\r', '\n');
         }
 
         public static string FindDnxDirectory()


### PR DESCRIPTION
`where dnx` returns multiple results on some machines and some tests fail.
This blocks the signed build both on release and dev.

Please review @rynowak 
Please approve for release @muratg 
cc @danroth27 