### PR TITLE
Use `XunitTheoryTestCaseRunner` for xUnit tests that are not pre-enumerated

### DIFF
--- a/src/Microsoft.AspNet.Testing/xunit/ConditionalAttributeDiscoverer.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/ConditionalAttributeDiscoverer.cs
@@ -25,9 +25,11 @@ namespace Microsoft.AspNet.Testing.xunit
         {
             var skipReason = EvaluateSkipConditions(testMethod);
 
+            var isTheory = false;
             IXunitTestCaseDiscoverer innerDiscoverer;
             if (testMethod.Method.GetCustomAttributes(typeof(TheoryAttribute)).Any())
             {
+                isTheory = true;
                 innerDiscoverer = new TheoryDiscoverer(_diagnosticMessageSink);
             }
             else
@@ -35,9 +37,11 @@ namespace Microsoft.AspNet.Testing.xunit
                 innerDiscoverer = new FactDiscoverer(_diagnosticMessageSink);
             }
 
-            var res = innerDiscoverer.Discover(discoveryOptions, testMethod, factAttribute)
-                      .Select(testCase => new SkipReasonTestCase(skipReason, testCase));
-            return res;
+            var testCases = innerDiscoverer
+                .Discover(discoveryOptions, testMethod, factAttribute)
+                .Select(testCase => new SkipReasonTestCase(isTheory, skipReason, testCase));
+
+            return testCases;
         }
 
         private string EvaluateSkipConditions(ITestMethod testMethod)

--- a/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Dnx.Runtime;
-using Microsoft.Dnx.Runtime.Infrastructure;
 
 namespace Microsoft.AspNet.Testing.xunit
 {

--- a/src/Microsoft.AspNet.Testing/xunit/SkipReasonTestCase.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/SkipReasonTestCase.cs
@@ -11,11 +11,13 @@ namespace Microsoft.AspNet.Testing.xunit
 {
     internal class SkipReasonTestCase : IXunitTestCase
     {
+        private readonly bool _isTheory;
         private readonly string _skipReason;
         private readonly IXunitTestCase _wrappedTestCase;
 
-        public SkipReasonTestCase(string skipReason, IXunitTestCase wrappedTestCase)
+        public SkipReasonTestCase(bool isTheory, string skipReason, IXunitTestCase wrappedTestCase)
         {
+            _isTheory = isTheory;
             _skipReason = wrappedTestCase.SkipReason ?? skipReason;
             _wrappedTestCase = wrappedTestCase;
         }
@@ -100,7 +102,33 @@ namespace Microsoft.AspNet.Testing.xunit
             ExceptionAggregator aggregator,
             CancellationTokenSource cancellationTokenSource)
         {
-            return new XunitTestCaseRunner(this, DisplayName, _skipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+            TestCaseRunner<IXunitTestCase> runner;
+            if (_isTheory)
+            {
+                runner = new XunitTheoryTestCaseRunner(
+                    this,
+                    DisplayName,
+                    _skipReason,
+                    constructorArguments,
+                    diagnosticMessageSink,
+                    messageBus,
+                    aggregator,
+                    cancellationTokenSource);
+            }
+            else
+            {
+                runner = new XunitTestCaseRunner(
+                    this,
+                    DisplayName,
+                    _skipReason,
+                    constructorArguments,
+                    TestMethodArguments,
+                    messageBus,
+                    aggregator,
+                    cancellationTokenSource);
+            }
+
+            return runner.RunAsync();
         }
 
         public void Serialize(IXunitSerializationInfo info)

--- a/src/Microsoft.Framework.Logging.Testing/project.json
+++ b/src/Microsoft.Framework.Logging.Testing/project.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "Microsoft.Framework.Logging.Abstractions": "1.0.0-*",
         "Microsoft.Framework.NotNullAttribute.Sources": { "version": "1.0.0-*", "type": "build" },
-        "xunit.assert": "2.0.0-rc3-*"
+        "xunit.assert": "2.1.0-*"
     },
     "frameworks": {
         "net45": {

--- a/src/Microsoft.Framework.WebEncoders.Testing/project.json
+++ b/src/Microsoft.Framework.WebEncoders.Testing/project.json
@@ -6,7 +6,7 @@
     },
     "dependencies": {
         "Microsoft.Framework.WebEncoders": "1.0.0-*",
-        "xunit.assert": "2.0.0-rc3-*"
+        "xunit.assert": "2.1.0-*"
     },
     "frameworks": {
         "net45": {


### PR DESCRIPTION
- react to aspnet/aspnet.xunit#13
- address issues with latest xUnit bits and `[ConditionalTheory]` tests with `[InlineData]`

nits:
- update slightly-older `xunit.assert` references to match `xunit.runner.aspnet` package
- remove a couple of unused `using`s