### PR TITLE
Remove dependency of Microsoft.Dnx.Runtime from Microsoft.Dnx.TestHost

### DIFF
--- a/src/Microsoft.Dnx.TestHost/Program.cs
+++ b/src/Microsoft.Dnx.TestHost/Program.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Runtime.Common.CommandLine;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Dnx.TestHost
@@ -62,7 +64,7 @@ namespace Microsoft.Dnx.TestHost
                     {
                         string testCommand = null;
                         Project project = null;
-                        if (Project.TryGetProject(projectPath, out project, diagnostics: null))
+                        if (Project.TryGetProject(projectPath, out project))
                         {
                             project.Commands.TryGetValue("test", out testCommand);
                         }
@@ -115,7 +117,7 @@ namespace Microsoft.Dnx.TestHost
 
                             var testServices = TestServices.CreateTestServices(_services, project, channel);
                             await ProjectCommand.Execute(testServices, project, "test", commandArgs);
-                            
+
                             channel.Send(new Message()
                             {
                                 MessageType = "TestDiscovery.Response",
@@ -144,7 +146,7 @@ namespace Microsoft.Dnx.TestHost
 
                             var testServices = TestServices.CreateTestServices(_services, project, channel);
                             await ProjectCommand.Execute(testServices, project, "test", commandArgs.ToArray());
-                            
+
                             channel.Send(new Message()
                             {
                                 MessageType = "TestExecution.Response",

--- a/src/Microsoft.Dnx.TestHost/Project.cs
+++ b/src/Microsoft.Dnx.TestHost/Project.cs
@@ -1,0 +1,89 @@
+﻿// Copyright(c) .NET Foundation.All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace Microsoft.Dnx.TestHost
+{
+    public class Project
+    {
+        private const string ProjectFileName = "project.json";
+
+        public string Name { get; set; }
+
+        public IDictionary<string, string> Commands { get; }
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        public static bool TryGetProject(string inputPath, out Project project)
+        {
+            string projectName;
+            var projectJsonPath = GetProjectJsonPath(inputPath, out projectName);
+
+            if (!File.Exists(projectJsonPath))
+            {
+                project = null;
+                return false;
+            }
+
+            using (var stream = File.OpenRead(projectJsonPath))
+            {
+                project = GetProject(stream, projectJsonPath, projectName);
+            }
+
+            return true;
+        }
+
+        // To enable unit testing
+        internal static string GetProjectJsonPath(string inputPath, out string projectName)
+        {
+            string projectDirectoryPath;
+            if (string.Equals(Path.GetFileName(inputPath), ProjectFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                // Example: for a path like "C:\github\mvc\project.json", the following api would return
+                // "C:\github\mvc"
+                projectDirectoryPath = Path.GetDirectoryName(inputPath);
+            }
+            else
+            {
+                projectDirectoryPath = inputPath;
+            }
+
+            // Assume the directory name is the project name if none was specified
+            projectName = GetDirectoryName(projectDirectoryPath);
+
+            return Path.GetFullPath(Path.Combine(projectDirectoryPath, ProjectFileName));
+        }
+
+        // To enable unit testing
+        internal static Project GetProject(Stream stream, string projectJsonPath, string projectName)
+        {
+            Project project;
+
+            try
+            {
+                var seriliazer = new JsonSerializer();
+                project = seriliazer.Deserialize<Project>(new JsonTextReader(new StreamReader(stream)));
+                project.Name = projectName;
+            }
+            catch (JsonReaderException ex)
+            {
+                throw new InvalidOperationException(
+                    $"The JSON file '{projectJsonPath}' can't be deserialized to a JSON object.", innerException: ex);
+            }
+
+            return project;
+        }
+
+        private static string GetDirectoryName(string path)
+        {
+            path = path.TrimEnd(Path.DirectorySeparatorChar);
+
+            return path
+                .Substring(Path.GetDirectoryName(path).Length)
+                .Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        }
+    }
+}

--- a/src/Microsoft.Dnx.TestHost/ProjectCommand.cs
+++ b/src/Microsoft.Dnx.TestHost/ProjectCommand.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Dnx.TestHost
     public static class ProjectCommand
     {
         public static async Task<int> Execute(
-            IServiceProvider services, 
+            IServiceProvider services,
             Project project,
             string command,
             string[] args)
@@ -23,7 +23,7 @@ namespace Microsoft.Dnx.TestHost
             var environment = (IApplicationEnvironment)services.GetService(typeof(IApplicationEnvironment));
             var commandText = project.Commands[command];
             var replacementArgs = CommandGrammar.Process(
-                commandText, 
+                commandText,
                 (key) => GetVariable(environment, key),
                 preserveSurroundingQuotes: false)
                 .ToArray();
@@ -34,7 +34,7 @@ namespace Microsoft.Dnx.TestHost
             if (string.IsNullOrEmpty(entryPoint) ||
                 string.Equals(entryPoint, "run", StringComparison.Ordinal))
             {
-                entryPoint = project.EntryPoint ?? project.Name;
+                entryPoint = project.Name;
             }
 
             CallContextServiceLocator.Locator.ServiceProvider = services;

--- a/src/Microsoft.Dnx.TestHost/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Dnx.TestHost/Properties/AssemblyInfo.cs
@@ -3,6 +3,8 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: NeutralResourcesLanguage("en-us")]
+[assembly: InternalsVisibleTo("Microsoft.Dnx.TestHost.Tests")]

--- a/src/Microsoft.Dnx.TestHost/project.json
+++ b/src/Microsoft.Dnx.TestHost/project.json
@@ -1,46 +1,50 @@
 {
-  "version": "1.0.0-*",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/aspnet/testing"
-  },
-  "compilationOptions": {
-    "warningsAsErrors": true
-  },
-  "dependencies": {
-    "Microsoft.Framework.CommandLineUtils.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "version": "1.0.0-*",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/aspnet/testing"
     },
-    "Microsoft.Framework.Logging": "1.0.0-*",
-    "Microsoft.Dnx.TestAdapter": "1.0.0-*",
-    "Microsoft.Dnx.Runtime": "1.0.0-*",
-    "Microsoft.Dnx.Compilation.Abstractions": "1.0.0-*",
-    "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "compilationOptions": {
+        "warningsAsErrors": true
     },
-    "Microsoft.Dnx.Runtime.Sources": {
-      "version": "1.0.0-*",
-      "type": "build"
+    "dependencies": {
+        "Microsoft.Dnx.Compilation.Abstractions": "1.0.0-*",
+        "Microsoft.Dnx.Runtime.CommandParsing.Sources": {
+            "version": "1.0.0-*",
+            "type": "build"
+        },
+        "Microsoft.Dnx.Runtime.Sources": {
+            "version": "1.0.0-*",
+            "type": "build"
+        },
+        "Microsoft.Dnx.TestAdapter": "1.0.0-*",
+        "Microsoft.Framework.CommandLineUtils.Sources": {
+            "version": "1.0.0-*",
+            "type": "build"
+        },
+        "Microsoft.Framework.Logging": "1.0.0-*",
+        "Newtonsoft.Json": "6.0.6"
     },
-    "Newtonsoft.Json": "6.0.6"
-  },
-  "commands": {
-    "run": "run"
-  },
-  "frameworks": {
-    "dnx451": { },
-    "dnxcore50": {
-      "dependencies": {
-        "System.Console": "4.0.0-beta-*",
-        "System.Diagnostics.Process": "4.0.0-beta-*",
-        "System.Diagnostics.TraceSource": "4.0.0-beta-*",
-        "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-*",
-        "System.Net.Primitives": "4.0.11-beta-*",
-        "System.Net.Sockets": "4.0.10-beta-*",
-        "System.Reflection.Extensions": "4.0.1-beta-*"
-      }
+    "commands": {
+        "run": "run"
+    },
+    "frameworks": {
+        "dnx451": {
+            "frameworkAssemblies": {
+                "System.Runtime": "4.0.0.0",
+                "System.Threading.Tasks": "4.0.0.0"
+            }
+        },
+        "dnxcore50": {
+            "dependencies": {
+                "System.Console": "4.0.0-beta-*",
+                "System.Diagnostics.Process": "4.0.0-beta-*",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-*",
+                "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-*",
+                "System.Net.Primitives": "4.0.11-beta-*",
+                "System.Net.Sockets": "4.0.10-beta-*",
+                "System.Reflection.Extensions": "4.0.1-beta-*"
+            }
+        }
     }
-  }
 }

--- a/test/Microsoft.Dnx.TestHost.Tests/ProjectTest.cs
+++ b/test/Microsoft.Dnx.TestHost.Tests/ProjectTest.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Microsoft.AspNet.Testing.xunit;
+using Microsoft.Dnx.Runtime;
+using Microsoft.Dnx.Runtime.Infrastructure;
+using Xunit;
+
+namespace Microsoft.Dnx.TestHost
+{
+    public class ProjectTest
+    {
+        private const string projectName = "Sample.Tests";
+        private const string ProjectJsonFileName = "project.json";
+        private readonly string _testProjectPath;
+
+        public ProjectTest()
+        {
+            var services = CallContextServiceLocator.Locator.ServiceProvider;
+
+            var libraryManager = (ILibraryManager)services.GetService(typeof(ILibraryManager));
+
+            // Example: "C:\github\testing\test\Sample.Tests"
+            _testProjectPath = Path.GetDirectoryName(libraryManager.GetLibrary(projectName).Path);
+        }
+
+        [Fact]
+        public void GetsProjectInfo_FromProjectDirectoryPath()
+        {
+            // Arrange
+            var projectDirPath = _testProjectPath;
+
+            // Act & Assert
+            Project project;
+            Assert.True(Project.TryGetProject(projectDirPath, out project));
+            Assert.NotNull(project);
+            Assert.Equal(projectName, project.Name);
+            Assert.NotNull(project.Commands);
+            Assert.Equal(1, project.Commands.Count);
+            string val;
+            Assert.True(project.Commands.TryGetValue("test", out val));
+            Assert.Equal("xunit.runner.aspnet", val);
+        }
+
+        [Fact]
+        public void GetsProjectInfo_FromPathHavingProjectJsonFile()
+        {
+            // Arrange
+            var projectJsonPath = Path.Combine(_testProjectPath, ProjectJsonFileName);
+
+            // Act & Assert
+            Project project;
+            Assert.True(Project.TryGetProject(projectJsonPath, out project));
+            Assert.NotNull(project);
+            Assert.Equal(projectName, project.Name);
+            Assert.NotNull(project.Commands);
+            Assert.Equal(1, project.Commands.Count);
+            string val;
+            Assert.True(project.Commands.TryGetValue("test", out val));
+            Assert.Equal("xunit.runner.aspnet", val);
+        }
+
+        [Fact]
+        public void GetsProjectInfo_FromRelativeProjectDirectoryPath()
+        {
+            // Arrange
+            var projectDirPath = string.Join(Path.DirectorySeparatorChar.ToString(), new[] { "..", projectName });
+
+            // Act & Assert
+            Project project;
+            Assert.True(Project.TryGetProject(projectDirPath, out project));
+            Assert.NotNull(project);
+            Assert.Equal(projectName, project.Name);
+            Assert.NotNull(project.Commands);
+            Assert.Equal(1, project.Commands.Count);
+            string val;
+            Assert.True(project.Commands.TryGetValue("test", out val));
+            Assert.Equal("xunit.runner.aspnet", val);
+        }
+
+        [Fact]
+        public void GetsProjectInfo_FromRelativePathHavingProjectJsonFile()
+        {
+            // Arrange
+            var projectDirPath = string.Join(
+                Path.DirectorySeparatorChar.ToString(), new[] { "..", projectName, ProjectJsonFileName });
+
+            // Act & Assert
+            Project project;
+            Assert.True(Project.TryGetProject(projectDirPath, out project));
+            Assert.NotNull(project);
+            Assert.Equal(projectName, project.Name);
+            Assert.NotNull(project.Commands);
+            Assert.Equal(1, project.Commands.Count);
+            string val;
+            Assert.True(project.Commands.TryGetValue("test", out val));
+            Assert.Equal("xunit.runner.aspnet", val);
+        }
+
+        [Fact]
+        public void ThrowsExceptionOnInvalidJsonContent()
+        {
+            // Arrange
+            var projectJsonPath = Path.Combine(_testProjectPath, ProjectJsonFileName);
+            var projectJsonContentStream = new MemoryStream(Encoding.UTF8.GetBytes("not a valid json content"));
+
+            // Act & Assert
+            var exception = Assert.Throws<InvalidOperationException>(() =>
+                Project.GetProject(projectJsonContentStream, projectJsonPath, projectName));
+            Assert.Equal(
+                $"The JSON file '{projectJsonPath}' can't be deserialized to a JSON object.", exception.Message);
+        }
+
+        [Fact]
+        public void CommandsSetIsEmptyByDefault()
+        {
+            // Arrange
+            var projectContent = @"{}";
+            var projectJsonPath = Path.Combine(_testProjectPath, "project.json");
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(projectContent));
+
+            // Act
+            var project = Project.GetProject(memoryStream, projectJsonPath, projectName);
+
+            // Assert
+            Assert.NotNull(project.Commands);
+            Assert.Equal(0, project.Commands.Count);
+        }
+
+        [Fact]
+        public void CommandsSetIsSet()
+        {
+            // Arrange
+            var projectContent = @"
+{
+    ""commands"": {
+        ""cmd1"": ""cmd1value"",
+        ""cmd2"": ""cmd2value"",
+        ""cmd3"": ""cmd3value""
+    }
+}";
+            var projectJsonPath = Path.Combine(_testProjectPath, "project.json");
+            var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(projectContent));
+
+            // Act
+            var project = Project.GetProject(memoryStream, projectJsonPath, projectName);
+
+            // Assert
+            Assert.NotNull(project.Commands);
+            Assert.Equal(3, project.Commands.Count);
+        }
+
+        public static TheoryData<string> InputPathWithoutProjectJsonData
+        {
+            get
+            {
+                var separator = Path.DirectorySeparatorChar.ToString();
+
+                return new TheoryData<string>()
+                {
+                    // ex: samples\todo
+                    string.Join(separator, new[] { "samples", "todo" }),
+
+                    // ex: samples\todo\
+                    string.Join(separator, new[] { "samples", "todo" }) + separator,
+
+                    // ex: ..\samples\todo
+                    string.Join(separator, new[] { "..", "samples", "todo" }),
+
+                    // ex: ..\samples\todo\
+                    string.Join(separator, new[] { "..", "samples", "todo" }) + separator
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(InputPathWithoutProjectJsonData))]
+        public void InputPathWithoutProjectJson_ReturnsFullPathWithProjectJson(string inputPath)
+        {
+            // Arrange & Act
+            string projectName;
+            var projectJsonPath = Project.GetProjectJsonPath(inputPath, out projectName);
+
+            // Assert
+            Assert.Equal(Path.GetFullPath(Path.Combine(inputPath, "project.json")), projectJsonPath);
+            Assert.Equal("todo", projectName);
+        }
+
+        public static TheoryData<string> RelativeInputPathWithProjectJsonData
+        {
+            get
+            {
+                var separator = Path.DirectorySeparatorChar.ToString();
+
+                return new TheoryData<string>()
+                {
+                    // ex: samples\todo\project.json
+                    string.Join(separator, new[] { "samples", "todo", "project.json" }),
+
+                    // ex: ..\samples\todo\project.json
+                    string.Join(separator, new[] { "..", "samples", "todo", "project.json" }),
+                };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(RelativeInputPathWithProjectJsonData))]
+        public void RelativeInputPathWithProjectJson_ReturnsFullPathWithProjectJson(string inputPath)
+        {
+            // Arrange & Act
+            string projectName;
+            var projectJsonPath = Project.GetProjectJsonPath(inputPath, out projectName);
+
+            // Assert
+            Assert.Equal(Path.GetFullPath(inputPath), projectJsonPath, ignoreCase: true);
+            Assert.Equal("todo", projectName);
+        }
+    }
+}

--- a/test/Microsoft.Framework.Logging.Testing.Tests/project.json
+++ b/test/Microsoft.Framework.Logging.Testing.Tests/project.json
@@ -8,10 +8,15 @@
         "test": "xunit.runner.aspnet"
     },
     "frameworks" : {
-        "dnx451" : { },
-        "dnxcore50" : { 
+        "dnx451": {
+            "frameworkAssemblies": {
+                "System.Threading.Tasks": "4.0.0.0"
+            }
+        },
+        "dnxcore50" : {
             "dependencies": {
-                "System.Runtime": "4.0.21-beta-*"
+                "System.Runtime": "4.0.21-beta-*",
+                "System.Threading.Tasks": "4.0.11-beta-*"
             }
         }
     }


### PR DESCRIPTION
@rynowak @muratg 

I ran bunch of repos against this change and some of them failed building due to the missing dependency for `System.Threading.Tasks` (as this was available transitively before my change). I made changes in these repos and will check them in first before this change.