### PR TITLE
Fixes ReplaceCulture attribute to use current UI culture and make Culture and UICulture be supplied via constructor

### DIFF
--- a/Testing.sln
+++ b/Testing.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		global.json = global.json
 	EndProjectSection
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.AspNet.Testing.Tests", "test\Microsoft.AspNet.Testing.Tests\Microsoft.AspNet.Testing.Tests.xproj", "{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A16C1BE-8777-473A-A581-02E10D82C49D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -102,5 +108,6 @@ Global
 		{F6958E64-32E4-4697-BFA8-0A78B7AB4CEA} = {09F799F3-E521-466F-B155-B89E2746C8C9}
 		{90C1A9CE-E402-4206-8194-03A844435FC3} = {5525B6EA-8BBB-4437-BD09-419AE380BBA8}
 		{2A16C1BE-8777-473A-A581-02E10D82C49D} = {57A90243-F8A5-4115-BA05-A1CEEBD8A5CD}
+		{C9F758D6-17A3-4BF1-BCCD-972B1DA959FC} = {09F799F3-E521-466F-B155-B89E2746C8C9}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.AspNet.Testing/ReplaceCulture.cs
+++ b/src/Microsoft.AspNet.Testing/ReplaceCulture.cs
@@ -17,30 +17,40 @@ namespace Microsoft.AspNet.Testing
     {
         private const string _defaultCultureName = "en-GB";
         private const string _defaultUICultureName = "en-US";
-        private static readonly CultureInfo _defaultCulture = new CultureInfo(_defaultCultureName);
         private CultureInfo _originalCulture;
         private CultureInfo _originalUICulture;
 
-        public ReplaceCultureAttribute()
+        /// <summary>
+        /// Replaces the current culture and UI culture to en-GB and en-US respectively.
+        /// </summary>
+        public ReplaceCultureAttribute() :
+            this(_defaultCultureName, _defaultUICultureName)
         {
-            Culture = _defaultCulture;
-            UICulture = _defaultCulture;
         }
 
         /// <summary>
-        /// Sets <see cref="Thread.CurrentCulture"/> for the test. Defaults to en-GB.
+        /// Replaces the current culture and UI culture based on specified values.
+        /// </summary>
+        public ReplaceCultureAttribute(string currentCulture, string currentUICulture)
+        {
+            Culture = new CultureInfo(currentCulture);
+            UICulture = new CultureInfo(currentUICulture);
+        }
+
+        /// <summary>
+        /// The <see cref="Thread.CurrentCulture"/> for the test. Defaults to en-GB.
         /// </summary>
         /// <remarks>
         /// en-GB is used here as the default because en-US is equivalent to the InvariantCulture. We
         /// want to be able to find bugs where we're accidentally relying on the Invariant instead of the
         /// user's culture.
         /// </remarks>
-        public CultureInfo Culture { get; set; }
+        public CultureInfo Culture { get; }
 
         /// <summary>
-        /// Sets <see cref="Thread.CurrentUICulture"/> for the test. Defaults to en-US.
+        /// The <see cref="Thread.CurrentUICulture"/> for the test. Defaults to en-US.
         /// </summary>
-        public CultureInfo UICulture { get; set; }
+        public CultureInfo UICulture { get; }
 
         public override void Before(MethodInfo methodUnderTest)
         {

--- a/test/Microsoft.AspNet.Testing.Tests/Microsoft.AspNet.Testing.Tests.xproj
+++ b/test/Microsoft.AspNet.Testing.Tests/Microsoft.AspNet.Testing.Tests.xproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c9f758d6-17a3-4bf1-bccd-972b1da959fc</ProjectGuid>
+    <RootNamespace>Microsoft.AspNet.Testing.Tests</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/test/Microsoft.AspNet.Testing.Tests/ReplaceCultureAttributeTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/ReplaceCultureAttributeTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using Xunit;
+
+namespace Microsoft.AspNet.Testing
+{
+    public class RepalceCultureAttributeTest
+    {
+        [Fact]
+        public void DefaultsTo_EnGB_EnUS()
+        {
+            // Arrange
+            var culture = new CultureInfo("en-GB");
+            var uiCulture = new CultureInfo("en-US");
+
+            // Act
+            var replaceCulture = new ReplaceCultureAttribute();
+
+            // Assert
+            Assert.Equal(culture, replaceCulture.Culture);
+            Assert.Equal(uiCulture, replaceCulture.UICulture);
+        }
+
+        [Fact]
+        public void UsesSuppliedCultureAndUICulture()
+        {
+            // Arrange
+            var culture = "de-DE";
+            var uiCulture = "fr-CA";
+
+            // Act
+            var replaceCulture = new ReplaceCultureAttribute(culture, uiCulture);
+
+            // Assert
+            Assert.Equal(new CultureInfo(culture), replaceCulture.Culture);
+            Assert.Equal(new CultureInfo(uiCulture), replaceCulture.UICulture);
+        }
+
+        [Fact]
+        public void BeforeAndAfterTest_ReplacesCulture()
+        {
+            // Arrange
+            var originalCulture = CultureInfo.CurrentCulture;
+            var originalUICulture = CultureInfo.CurrentUICulture;
+            var culture = "de-DE";
+            var uiCulture = "fr-CA";
+            var replaceCulture = new ReplaceCultureAttribute(culture, uiCulture);
+
+            // Act
+            replaceCulture.Before(methodUnderTest: null);
+
+            // Assert
+            Assert.Equal(new CultureInfo(culture), CultureInfo.CurrentCulture);
+            Assert.Equal(new CultureInfo(uiCulture), CultureInfo.CurrentUICulture);
+
+            // Act
+            replaceCulture.After(methodUnderTest: null);
+
+            // Assert
+            Assert.Equal(originalCulture, CultureInfo.CurrentCulture);
+            Assert.Equal(originalUICulture, CultureInfo.CurrentUICulture);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.Testing.Tests/project.json
+++ b/test/Microsoft.AspNet.Testing.Tests/project.json
@@ -1,0 +1,14 @@
+{
+    "version": "1.0.0-*",
+    "dependencies": {
+        "Microsoft.AspNet.Testing": "1.0.0-*",
+        "xunit.runner.aspnet": "2.0.0-aspnet-*"
+    },
+    "commands": {
+        "test": "xunit.runner.aspnet"
+    },
+    "frameworks": {
+        "dnx451": { },
+        "dnxcore50": { }
+    }
+}


### PR DESCRIPTION
@dougbu @NTaylorMullen 

Fixes: https://github.com/aspnet/Testing/issues/61 and https://github.com/aspnet/Testing/issues/126