### PR TITLE
Make `SkipReason` properties settable

### DIFF
--- a/src/Microsoft.AspNet.Testing/project.json
+++ b/src/Microsoft.AspNet.Testing/project.json
@@ -11,9 +11,9 @@
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "",
-                "System.Reflection": "",
-                "System.Threading.Tasks": ""
+                "System.Runtime": "4.0.10.0",
+                "System.Reflection": "4.0.0.0",
+                "System.Threading.Tasks": "4.0.0.0"
             }
         },
         "dnxcore50": {

--- a/src/Microsoft.AspNet.Testing/project.json
+++ b/src/Microsoft.AspNet.Testing/project.json
@@ -11,9 +11,9 @@
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.10.0",
-                "System.Reflection": "4.0.0.0",
-                "System.Threading.Tasks": "4.0.0.0"
+                "System.Runtime": "",
+                "System.Reflection": "",
+                "System.Threading.Tasks": ""
             }
         },
         "dnxcore50": {

--- a/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/FrameworkSkipConditionAttribute.cs
@@ -23,15 +23,9 @@ namespace Microsoft.AspNet.Testing.xunit
             }
         }
 
-        public string SkipReason
-        {
-            get
-            {
-                return "Test cannot run on this runtime framework.";
-            }
-        }
+        public string SkipReason { get; set; } = "Test cannot run on this runtime framework.";
 
-        private bool CanRunOnThisFramework(RuntimeFrameworks excludedFrameworks)
+        private static bool CanRunOnThisFramework(RuntimeFrameworks excludedFrameworks)
         {
             if (excludedFrameworks == RuntimeFrameworks.None)
             {

--- a/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
@@ -23,27 +23,21 @@ namespace Microsoft.AspNet.Testing.xunit
             }
         }
 
-        public string SkipReason
-        {
-            get
-            {
-                return "Test cannot run on this operating system.";
-            }
-        }
+        public string SkipReason { get; set; } = "Test cannot run on this operating system.";
 
-        private bool CanRunOnThisOS(OperatingSystems excludedOperatingSystems)
+        private static bool CanRunOnThisOS(OperatingSystems excludedOperatingSystems)
         {
             if (excludedOperatingSystems == OperatingSystems.None)
             {
                 return true;
             }
 
-            switch (TestPlatformHelper.RuntimeEnvironment.OperatingSystem)
+            switch (TestPlatformHelper.RuntimeEnvironment.OperatingSystem.ToLowerInvariant())
             {
-                case "Windows":
+                case "windows":
                     var osVersion = new Version(TestPlatformHelper.RuntimeEnvironment.OperatingSystemVersion);
 
-                    // The GetVersion API has a back compat feature: for apps that are not manifested 
+                    // The GetVersion API has a back compat feature: for apps that are not manifested
                     // and run on Windows 8.1, it returns version 6.2 rather than 6.3. See this:
                     // http://msdn.microsoft.com/en-us/library/windows/desktop/ms724439(v=vs.85).aspx
                     if (osVersion.Major == 6)
@@ -56,13 +50,13 @@ namespace Microsoft.AspNet.Testing.xunit
                         }
                     }
                     break;
-                case "Linux":
+                case "linux":
                     if (excludedOperatingSystems.HasFlag(OperatingSystems.Linux))
                     {
                         return false;
                     }
                     break;
-                case "Darwin":
+                case "darwin":
                     if (excludedOperatingSystems.HasFlag(OperatingSystems.MacOSX))
                     {
                         return false;

--- a/src/Microsoft.Dnx.TestHost/project.json
+++ b/src/Microsoft.Dnx.TestHost/project.json
@@ -31,8 +31,8 @@
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.10.0",
-                "System.Threading.Tasks": "4.0.0.0"
+                "System.Runtime": "",
+                "System.Threading.Tasks": ""
             }
         },
         "dnxcore50": {

--- a/src/Microsoft.Dnx.TestHost/project.json
+++ b/src/Microsoft.Dnx.TestHost/project.json
@@ -31,7 +31,7 @@
     "frameworks": {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.0.0",
+                "System.Runtime": "4.0.10.0",
                 "System.Threading.Tasks": "4.0.0.0"
             }
         },

--- a/src/Microsoft.Framework.Logging.Testing/project.json
+++ b/src/Microsoft.Framework.Logging.Testing/project.json
@@ -16,7 +16,7 @@
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.0.0"
+                "System.Runtime": "4.0.10.0"
             }
         },
         "dnxcore50": { }

--- a/src/Microsoft.Framework.Logging.Testing/project.json
+++ b/src/Microsoft.Framework.Logging.Testing/project.json
@@ -11,12 +11,12 @@
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.0.0"
+                "System.Runtime": ""
             }
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.10.0"
+                "System.Runtime": ""
             }
         },
         "dnxcore50": { }

--- a/src/Microsoft.Framework.WebEncoders.Testing/project.json
+++ b/src/Microsoft.Framework.WebEncoders.Testing/project.json
@@ -16,7 +16,7 @@
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.0.0"
+                "System.Runtime": "4.0.10.0"
             }
         },
         "dnxcore50": { }

--- a/src/Microsoft.Framework.WebEncoders.Testing/project.json
+++ b/src/Microsoft.Framework.WebEncoders.Testing/project.json
@@ -11,12 +11,12 @@
     "frameworks": {
         "net45": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.0.0"
+                "System.Runtime": ""
             }
         },
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Runtime": "4.0.10.0"
+                "System.Runtime": ""
             }
         },
         "dnxcore50": { }

--- a/test/Microsoft.AspNet.Testing.Tests/Microsoft.AspNet.Testing.Tests.xproj
+++ b/test/Microsoft.AspNet.Testing.Tests/Microsoft.AspNet.Testing.Tests.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.Framework.Logging.Testing.Tests/project.json
+++ b/test/Microsoft.Framework.Logging.Testing.Tests/project.json
@@ -10,7 +10,7 @@
     "frameworks" : {
         "dnx451": {
             "frameworkAssemblies": {
-                "System.Threading.Tasks": "4.0.0.0"
+                "System.Threading.Tasks": ""
             }
         },
         "dnxcore50" : {


### PR DESCRIPTION
Also update `dnx451` dependencies to match current reality
- avoid warnings about incorrect `System.Runtime` versions