### PR TITLE
Checking it builds

### DIFF
--- a/src/Microsoft.Dnx.TestHost/TestServices.cs
+++ b/src/Microsoft.Dnx.TestHost/TestServices.cs
@@ -3,13 +3,13 @@
 
 using System;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Dnx.Testing.Abstractions;
 using Microsoft.Dnx.TestHost.TestAdapter;
 using Microsoft.Dnx.Runtime.Common.DependencyInjection;
 using Microsoft.Dnx.Runtime;
 using Microsoft.Dnx.Compilation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.Dnx.TestHost
 {


### PR DESCRIPTION
https://www.myget.org/feed/aspnetcidev/package/nuget/Microsoft.Dnx.TestHost is on 1.0.0-rc1-15773

but compiles are breaking with Unable to locate Dependency Microsoft.Dnx.TestHost >= 1.0.0-rc1-15775