### PR TITLE
Add System.Reflection.TypeExtensions dependency to TestHost

### DIFF
--- a/src/Microsoft.Dnx.TestHost/project.json
+++ b/src/Microsoft.Dnx.TestHost/project.json
@@ -41,11 +41,12 @@
             "dependencies": {
                 "System.Console": "4.0.0-beta-*",
                 "System.Diagnostics.Process": "4.1.0-beta-*",
-                "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Diagnostics.TextWriterTraceListener": "4.0.0-beta-*",
+                "System.Diagnostics.TraceSource": "4.0.0-beta-*",
                 "System.Net.Primitives": "4.0.11-beta-*",
                 "System.Net.Sockets": "4.1.0-beta-*",
                 "System.Reflection.Extensions": "4.0.1-beta-*",
+                "System.Reflection.TypeExtensions": "4.0.1-beta-*",
                 "System.Threading.Thread": "4.0.0-beta-*"
             }
         }


### PR DESCRIPTION
This fixes a build error related to missing 'BindingFlags' and 'GetMethod'