### PR TITLE
New attribute to skip tests based on an environment variable.

### DIFF
--- a/src/Microsoft.AspNet.Testing/xunit/EnvironmentVariableSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/EnvironmentVariableSkipConditionAttribute.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Testing.xunit;
+
+namespace Microsoft.AspNet.Testing.xunit
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class EnvironmentVariableSkipConditionAttribute : Attribute, ITestCondition
+    {
+        private readonly string _environmentVariableName;
+        private readonly string _environmentVariableValue;
+
+        public EnvironmentVariableSkipConditionAttribute(string environmentVariableName, string environmentVariableValue)
+        {
+            _environmentVariableName = environmentVariableName;
+            _environmentVariableValue = environmentVariableValue;
+            SkipReason = $"Test cannot run when environment variable {environmentVariableName} is set to {environmentVariableValue}";
+        }
+
+        public bool IsMet
+        {
+            get
+            {
+                var skip = _environmentVariableValue.Equals(Environment.GetEnvironmentVariable(_environmentVariableName));
+                return !skip;
+            }
+        }
+
+        public string SkipReason { get; set; }
+    }
+}

--- a/src/Microsoft.AspNet.Testing/xunit/EnvironmentVariableSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/EnvironmentVariableSkipConditionAttribute.cs
@@ -12,7 +12,8 @@ namespace Microsoft.AspNet.Testing.xunit
         private readonly string _environmentVariableName;
         private readonly string _environmentVariableValue;
 
-        public EnvironmentVariableSkipConditionAttribute(string environmentVariableName, string environmentVariableValue)
+        public EnvironmentVariableSkipConditionAttribute(
+            string environmentVariableName, string environmentVariableValue)
         {
             _environmentVariableName = environmentVariableName;
             _environmentVariableValue = environmentVariableValue;
@@ -23,7 +24,8 @@ namespace Microsoft.AspNet.Testing.xunit
         {
             get
             {
-                var skip = _environmentVariableValue.Equals(Environment.GetEnvironmentVariable(_environmentVariableName));
+                var currentValue = Environment.GetEnvironmentVariable(_environmentVariableName);
+                var skip = string.Equals(currentValue, _environmentVariableValue);
                 return !skip;
             }
         }

--- a/test/Microsoft.AspNet.Testing.Tests/EnvironmentVariableSkipConditionAttributeTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/EnvironmentVariableSkipConditionAttributeTest.cs
@@ -22,6 +22,8 @@ namespace Microsoft.AspNet.Testing.Tests
 
             // Assert
             Assert.False(attribute.IsMet);
+
+            Environment.SetEnvironmentVariable(environmentVariableName, null);
         }
 
         [Fact]
@@ -36,6 +38,8 @@ namespace Microsoft.AspNet.Testing.Tests
 
             // Assert
             Assert.True(attribute.IsMet);
+
+            Environment.SetEnvironmentVariable(environmentVariableName, null);
         }
 
         [Fact]
@@ -47,9 +51,11 @@ namespace Microsoft.AspNet.Testing.Tests
 
             // Act
             var attribute = new EnvironmentVariableSkipConditionAttribute(environmentVariableName, "Value");
-
+            
             // Assert
             Assert.True(attribute.IsMet);
+
+            Environment.SetEnvironmentVariable(environmentVariableName, null);
         }
     }
 }

--- a/test/Microsoft.AspNet.Testing.Tests/EnvironmentVariableSkipConditionAttributeTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/EnvironmentVariableSkipConditionAttributeTest.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNet.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.AspNet.Testing.Tests
+{
+    public class EnvironmentVariableSkipConditionAttributeTest
+    {
+        [Fact]
+        public void Skips_WhenEnvironmentVariableIsSetToValue()
+        {
+            // Arrange
+            var environmentVariableName = "ATTRIBUTE_TEST_ENV_VAR";
+            var environmentVariableValue = "Value";
+            Environment.SetEnvironmentVariable(environmentVariableName, environmentVariableValue);
+
+            // Act
+            var attribute = new EnvironmentVariableSkipConditionAttribute(environmentVariableName, environmentVariableValue);
+
+            // Assert
+            Assert.False(attribute.IsMet);
+        }
+
+        [Fact]
+        public void DoesNotSkip_WhenEnvironmentVariableIsNotSet()
+        {
+            // Arrange
+            var environmentVariableName = "ATTRIBUTE_TEST_ENV_VAR";
+            Environment.SetEnvironmentVariable(environmentVariableName, null);
+
+            // Act
+            var attribute = new EnvironmentVariableSkipConditionAttribute(environmentVariableName, "Value");
+
+            // Assert
+            Assert.True(attribute.IsMet);
+        }
+
+        [Fact]
+        public void DoesNotSkip_WhenEnvironmentVariableIsSetToDifferentValue()
+        {
+            // Arrange
+            var environmentVariableName = "ATTRIBUTE_TEST_ENV_VAR";
+            Environment.SetEnvironmentVariable(environmentVariableName, "Other value");
+
+            // Act
+            var attribute = new EnvironmentVariableSkipConditionAttribute(environmentVariableName, "Value");
+
+            // Assert
+            Assert.True(attribute.IsMet);
+        }
+    }
+}


### PR DESCRIPTION
Attribute to skip tests if an environment variable is set to a given value.

We need this to move on with https://github.com/aspnet/KestrelHttpServer/pull/373. Travis currently has issues with IPv6 (https://github.com/travis-ci/travis-ci/issues/4964). We want to be able to skip certain tests on Travis (which defined the TRAVIS environment variable) but not on our CI.

cc @halter73 @troydai 
