### PR TITLE
Correct `TestPlatformHelper.IsLinux` and `IsMac` implementations

### DIFF
--- a/src/Microsoft.AspNet.Testing/TestPlatformHelper.cs
+++ b/src/Microsoft.AspNet.Testing/TestPlatformHelper.cs
@@ -8,14 +8,21 @@ namespace Microsoft.AspNet.Testing
 {
     public static class TestPlatformHelper
     {
-        private static Lazy<IRuntimeEnvironment> _runtimeEnv = new Lazy<IRuntimeEnvironment>(() => PlatformServices.Default.Runtime);
+        private static Lazy<IRuntimeEnvironment> _runtimeEnv = new Lazy<IRuntimeEnvironment>(
+            () => PlatformServices.Default.Runtime);
 
-        private static Lazy<bool> _isMono = new Lazy<bool>(() => RuntimeEnvironment.RuntimeType.Equals("Mono", StringComparison.OrdinalIgnoreCase));
-        private static Lazy<bool> _isWindows = new Lazy<bool>(() => RuntimeEnvironment.OperatingSystem.Equals("Windows", StringComparison.OrdinalIgnoreCase));
-        private static Lazy<bool> _isLinux = new Lazy<bool>(() => RuntimeEnvironment.OperatingSystem.Equals("Linux", StringComparison.OrdinalIgnoreCase));
-        private static Lazy<bool> _isMac = new Lazy<bool>(() => RuntimeEnvironment.OperatingSystem.Equals("Darwin", StringComparison.OrdinalIgnoreCase));
+        private static Lazy<bool> _isMono = new Lazy<bool>(
+            () => RuntimeEnvironment.RuntimeType.Equals("Mono", StringComparison.OrdinalIgnoreCase));
+
+        private static Lazy<bool> _isWindows = new Lazy<bool>(
+            () => RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows);
+        private static Lazy<bool> _isLinux = new Lazy<bool>(
+            () => RuntimeEnvironment.OperatingSystemPlatform == Platform.Linux);
+        private static Lazy<bool> _isMac = new Lazy<bool>(
+            () => RuntimeEnvironment.OperatingSystemPlatform == Platform.Darwin);
 
         public static bool IsMono { get { return _isMono.Value; } }
+
         public static bool IsWindows { get { return _isWindows.Value; } }
         public static bool IsLinux { get { return _isLinux.Value; } }
         public static bool IsMac { get { return _isMac.Value; } }

--- a/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNet.Testing/xunit/OSSkipConditionAttribute.cs
@@ -51,7 +51,6 @@ namespace Microsoft.AspNet.Testing.xunit
 
         private OSInfo GetCurrentOSInfo()
         {
-            var currentOS = _runtimeEnvironment.OperatingSystem;
             var currentOSVersion = _runtimeEnvironment.OperatingSystemVersion;
 
             OperatingSystems os;

--- a/test/Microsoft.AspNet.Testing.Tests/OSSkipConditionAttributeTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/OSSkipConditionAttributeTest.cs
@@ -2,12 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNet.Testing.xunit;
-using Microsoft.Dnx.Runtime;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
 
-namespace Microsoft.AspNet.Testing.Tests
+namespace Microsoft.AspNet.Testing.xunit
 {
     public class OSSkipConditionAttributeTest
     {

--- a/test/Microsoft.AspNet.Testing.Tests/OSSkipConditionTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/OSSkipConditionTest.cs
@@ -1,13 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.AspNet.Testing.xunit;
 using Microsoft.Extensions.PlatformAbstractions;
 using Xunit;
 
-namespace Microsoft.Dnx.TestHost.Tests
+namespace Microsoft.AspNet.Testing.xunit
 {
-    public class OSSkipConditionFacts
+    public class OSSkipConditionTest
     {
         private IRuntimeEnvironment RuntimeEnvironment
         {
@@ -22,7 +21,7 @@ namespace Microsoft.Dnx.TestHost.Tests
         public void TestSkipLinux()
         {
             Assert.False(
-                "linux" == RuntimeEnvironment.OperatingSystem.ToLowerInvariant(),
+                RuntimeEnvironment.OperatingSystemPlatform == Platform.Linux,
                 "Test should not be running on Linux");
         }
 
@@ -31,7 +30,7 @@ namespace Microsoft.Dnx.TestHost.Tests
         public void TestSkipMacOSX()
         {
             Assert.False(
-                "darwin" == RuntimeEnvironment.OperatingSystem.ToLowerInvariant(),
+                RuntimeEnvironment.OperatingSystemPlatform == Platform.Darwin,
                 "Test should not be running on MacOSX.");
         }
 
@@ -40,7 +39,7 @@ namespace Microsoft.Dnx.TestHost.Tests
         public void RunTest_DoesNotRunOnWin7OrWin2008R2()
         {
             Assert.False(
-                RuntimeEnvironment.OperatingSystem.ToLowerInvariant() == "windows" &&
+                RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows &&
                 RuntimeEnvironment.OperatingSystemVersion == "6.1",
                 "Test should not be running on Win7 or Win2008R2.");
         }
@@ -50,7 +49,7 @@ namespace Microsoft.Dnx.TestHost.Tests
         public void TestSkipWindows()
         {
             Assert.False(
-                "windows" == RuntimeEnvironment.OperatingSystem.ToLowerInvariant(),
+                RuntimeEnvironment.OperatingSystemPlatform == Platform.Windows,
                 "Test should not be running on Windows.");
         }
     }

--- a/test/Microsoft.AspNet.Testing.Tests/TestPlatformHelperTest.cs
+++ b/test/Microsoft.AspNet.Testing.Tests/TestPlatformHelperTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.AspNet.Testing.xunit;
+using Xunit;
+
+namespace Microsoft.AspNet.Testing
+{
+    public class TestPlatformHelperTest
+    {
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        [OSSkipCondition(OperatingSystems.Windows)]
+        public void IsLinux_TrueOnLinux()
+        {
+            Assert.True(TestPlatformHelper.IsLinux);
+            Assert.False(TestPlatformHelper.IsMac);
+            Assert.False(TestPlatformHelper.IsWindows);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.Windows)]
+        public void IsMac_TrueOnMac()
+        {
+            Assert.False(TestPlatformHelper.IsLinux);
+            Assert.True(TestPlatformHelper.IsMac);
+            Assert.False(TestPlatformHelper.IsWindows);
+        }
+
+        [ConditionalFact]
+        [OSSkipCondition(OperatingSystems.Linux)]
+        [OSSkipCondition(OperatingSystems.MacOSX)]
+        public void IsWindows_TrueOnWindows()
+        {
+            Assert.False(TestPlatformHelper.IsLinux);
+            Assert.False(TestPlatformHelper.IsMac);
+            Assert.True(TestPlatformHelper.IsWindows);
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.CLR | RuntimeFrameworks.CoreCLR | RuntimeFrameworks.None)]
+        public void IsMono_TrueOnMono()
+        {
+            Assert.True(TestPlatformHelper.IsMono);
+        }
+
+        [ConditionalFact]
+        [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
+        public void IsMono_FalseElsewhere()
+        {
+            Assert.False(TestPlatformHelper.IsMono);
+        }
+    }
+}


### PR DESCRIPTION
- #193
- previously relied on `OperatingSystem` string which can have many values
  - some xplat tests e.g. MVC repo on Mac are currently failing due to this bug
- add `TestPlatformHelperTest`

nits:
- remove unused variable from `[OSSkipCondition]`
- clean up some long lines
- move `OSSkipConditionAttributeTest` to correct namespace
- move `OSSkipConditionFacts` to correct project, fix its namespace and rename class