### PR TITLE
Fix disappearing xunit tests on big .NET

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/CultureReplacer.cs
+++ b/src/Microsoft.AspNetCore.Testing/CultureReplacer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.AspNetCore.Testing
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
             _threadId = Thread.CurrentThread.ManagedThreadId;
-#if DNX451
+#if NET451
             Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
             Thread.CurrentThread.CurrentUICulture = new CultureInfo(uiCulture);
 #else
@@ -71,7 +71,7 @@ namespace Microsoft.AspNetCore.Testing
             {
                 Assert.True(Thread.CurrentThread.ManagedThreadId == _threadId,
                     "The current thread is not the same as the thread invoking the constructor. This should never happen.");
-#if DNX451
+#if NET451
                 Thread.CurrentThread.CurrentCulture = _originalCulture;
                 Thread.CurrentThread.CurrentUICulture = _originalUICulture;
 #else

--- a/src/Microsoft.AspNetCore.Testing/ReplaceCulture.cs
+++ b/src/Microsoft.AspNetCore.Testing/ReplaceCulture.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNetCore.Testing
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
 
-#if DNX451
+#if NET451
             Thread.CurrentThread.CurrentCulture = Culture;
             Thread.CurrentThread.CurrentUICulture = UICulture;
 #else
@@ -69,7 +69,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public override void After(MethodInfo methodUnderTest)
         {
-#if DNX451
+#if NET451
             Thread.CurrentThread.CurrentCulture = _originalCulture;
             Thread.CurrentThread.CurrentUICulture = _originalUICulture;
 #else

--- a/src/Microsoft.AspNetCore.Testing/project.json
+++ b/src/Microsoft.AspNetCore.Testing/project.json
@@ -15,11 +15,11 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnx451": {
+    "net451": {
       "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.Reflection": "",
-        "System.Threading.Tasks": ""
+        "System.Runtime": {"type": "build" },
+        "System.Reflection": {"type": "build" },
+        "System.Threading.Tasks": {"type": "build" }
       }
     },
     "dnxcore50": {

--- a/src/Microsoft.AspNetCore.Testing/xunit/SkipReasonTestCase.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/SkipReasonTestCase.cs
@@ -9,7 +9,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Testing.xunit
 {
-    internal class SkipReasonTestCase : IXunitTestCase
+    internal class SkipReasonTestCase : LongLivedMarshalByRefObject, IXunitTestCase
     {
         private readonly bool _isTheory;
         private readonly string _skipReason;

--- a/test/Microsoft.AspNetCore.Testing.Tests/project.json
+++ b/test/Microsoft.AspNetCore.Testing.Tests/project.json
@@ -10,15 +10,7 @@
     "xunit": "2.1.0"
   },
   "frameworks": {
-    "dnx451": {
-      "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.Threading.Tasks": ""
-      },
-      "dependencies": {
-        "xunit.runner.console": "2.1.0"
-      }
-    },
+    "net451": { },
     "dnxcore50": {
       "dependencies": {
         "xunit.runner.aspnet": "2.0.0-aspnet-*"


### PR DESCRIPTION
Fix #203 (see https://github.com/xunit/xunit/issues/764 for more info)

It appears dnx451 and appdomain boundaries don't play well.
