### PR TITLE
Only check for TimeoutException in TimeoutAfterTest.

### DIFF
--- a/test/Microsoft.AspNetCore.Testing.Tests/TaskExtensionsTest.cs
+++ b/test/Microsoft.AspNetCore.Testing.Tests/TaskExtensionsTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,12 +12,7 @@ namespace Microsoft.AspNetCore.Testing
         [Fact]
         public async Task TimeoutAfterTest()
         {
-            const double timeoutMilliseconds = 100;
-            var sw = new Stopwatch();
-            sw.Start();
-            await Assert.ThrowsAsync<TimeoutException>(async () =>
-                await Task.Run(async () => await Task.Delay(1000)).TimeoutAfter(TimeSpan.FromMilliseconds(timeoutMilliseconds)));
-            Assert.True(sw.ElapsedMilliseconds >= timeoutMilliseconds);
+            await Assert.ThrowsAsync<TimeoutException>(async () => await Task.Delay(1000).TimeoutAfter(TimeSpan.FromMilliseconds(50)));
         }
     }
 }


### PR DESCRIPTION
Test is flaky when checking for time because there's some imprecision there. The test expects a timeout after 100ms but we're seeing it timeout at ~97ms sometimes.

cc @mikeharder @rynowak @BrennanConroy 