### PR TITLE
fix osskipcondition and Windows versions

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/xunit/OSSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/OSSkipConditionAttribute.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
                 if (_excludedVersions.Any())
                 {
                     skip = skip
-                        && _excludedVersions.Contains(currentOSInfo.Version, StringComparer.OrdinalIgnoreCase);
+                        && _excludedVersions.Any(ex => _osVersion.StartsWith(ex, StringComparison.OrdinalIgnoreCase));
                 }
 
                 // Since a test would be excuted only if 'IsMet' is true, return false if we want to skip

--- a/src/Microsoft.AspNetCore.Testing/xunit/WindowsVersions.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/WindowsVersions.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Testing.xunit
     {
         public const string Win7 = "6.1";
 
-        public const string Win2008R2 = "6.1";
+        public const string Win2008R2 = Win7;
     }
 }

--- a/test/Microsoft.AspNetCore.Testing.Tests/OSSkipConditionTest.cs
+++ b/test/Microsoft.AspNetCore.Testing.Tests/OSSkipConditionTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
         {
             Assert.False(
                 RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-                Microsoft.Extensions.Internal.RuntimeEnvironment.OperatingSystemVersion == "6.1",
+                Microsoft.Extensions.Internal.RuntimeEnvironment.OperatingSystemVersion.StartsWith("6.1"),
                 "Test should not be running on Win7 or Win2008R2.");
         }
 


### PR DESCRIPTION
`RuntimeEnvironment.OperatingSystemVersion` returns `6.1.[build number]` so this was broken, it appears.

/cc @pranavkm @BrennanConroy 