### PR TITLE
Fix SkipReasonTestCase to allow serialization and deserialization.

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/xunit/ConditionalAttributeDiscoverer.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/ConditionalAttributeDiscoverer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
@@ -39,7 +40,15 @@ namespace Microsoft.AspNetCore.Testing.xunit
 
             var testCases = innerDiscoverer
                 .Discover(discoveryOptions, testMethod, factAttribute)
-                .Select(testCase => new SkipReasonTestCase(isTheory, skipReason, testCase));
+                .Select(testCase => new SkipReasonTestCase
+                {
+                    IsTheory = isTheory,
+                    SkipReason = skipReason,
+                    SourceInformation = testCase.SourceInformation,
+                    TestMethod = testCase.TestMethod,
+                    TestMethodArguments = testCase.TestMethodArguments,
+                    UniqueID = testCase.UniqueID,
+                });
 
             return testCases;
         }


### PR DESCRIPTION
- With CSproj based test runners test cases are passed across application boundaries which require test cases to be serializable.

https://github.com/Microsoft/vstest/issues/291