### PR TITLE
Bump .NET Framework target to net452 (#244)

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/CultureReplacer.cs
+++ b/src/Microsoft.AspNetCore.Testing/CultureReplacer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNetCore.Testing
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
             _threadId = Thread.CurrentThread.ManagedThreadId;
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = culture;
             Thread.CurrentThread.CurrentUICulture = uiCulture;
 #else
@@ -76,7 +76,7 @@ namespace Microsoft.AspNetCore.Testing
             {
                 Assert.True(Thread.CurrentThread.ManagedThreadId == _threadId,
                     "The current thread is not the same as the thread invoking the constructor. This should never happen.");
-#if NET451
+#if NET452
                 Thread.CurrentThread.CurrentCulture = _originalCulture;
                 Thread.CurrentThread.CurrentUICulture = _originalUICulture;
 #else

--- a/src/Microsoft.AspNetCore.Testing/Functional/ProjectToolScenario.cs
+++ b/src/Microsoft.AspNetCore.Testing/Functional/ProjectToolScenario.cs
@@ -137,7 +137,7 @@ namespace Microsoft.AspNetCore.Testing.Functional
                 {
                     var varKey = newEnvVar.Key;
                     var varValue = newEnvVar.Value;
-#if NET451
+#if NET452
                     psi.EnvironmentVariables[varKey] = varValue;
 
 #else

--- a/src/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <Description>Various helpers for writing tests that use ASP.NET Core.</Description>
-    <TargetFrameworks>net451;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>

--- a/src/Microsoft.AspNetCore.Testing/ReplaceCulture.cs
+++ b/src/Microsoft.AspNetCore.Testing/ReplaceCulture.cs
@@ -37,7 +37,7 @@ namespace Microsoft.AspNetCore.Testing
             UICulture = new CultureInfo(currentUICulture);
         }
 
-#if NET451
+#if NET452
         /// <summary>
         /// The <see cref="Thread.CurrentCulture"/> for the test. Defaults to en-GB.
         /// </summary>
@@ -58,7 +58,7 @@ namespace Microsoft.AspNetCore.Testing
 #endif
         public CultureInfo Culture { get; }
 
-#if NET451
+#if NET452
         /// <summary>
         /// The <see cref="Thread.CurrentUICulture"/> for the test. Defaults to en-US.
         /// </summary>
@@ -74,7 +74,7 @@ namespace Microsoft.AspNetCore.Testing
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
 
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = Culture;
             Thread.CurrentThread.CurrentUICulture = UICulture;
 #else
@@ -86,7 +86,7 @@ namespace Microsoft.AspNetCore.Testing
 
         public override void After(MethodInfo methodUnderTest)
         {
-#if NET451
+#if NET452
             Thread.CurrentThread.CurrentCulture = _originalCulture;
             Thread.CurrentThread.CurrentUICulture = _originalUICulture;
 #else

--- a/src/Microsoft.AspNetCore.Testing/xunit/FrameworkSkipConditionAttribute.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/FrameworkSkipConditionAttribute.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNetCore.Testing.xunit
                 return true;
             }
 
-#if NET451
+#if NET452
             if (excludedFrameworks.HasFlag(RuntimeFrameworks.Mono) &&
                 TestPlatformHelper.IsMono)
             {


### PR DESCRIPTION
With xUnit moving to `net452` we've been bumping out test projects to that target, but `Microsoft.AspNetCore.Testing` should be bumped too since it references xUnit packages. Seems like that picks a fix to test discovery/execution and resolves #244.

@NTaylorMullen @natemcmaster @dougbu 