### PR TITLE
Include filepath and line number in timeout exception message

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/TaskExtensions.cs
+++ b/src/Microsoft.AspNetCore.Testing/TaskExtensions.cs
@@ -2,13 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Testing
 {
     public static class TaskExtensions
     {
-        public static async Task<T> TimeoutAfter<T>(this Task<T> task, TimeSpan timeout)
+        public static async Task<T> TimeoutAfter<T>(this Task<T> task, TimeSpan timeout,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default(int))
         {
             if (task == await Task.WhenAny(task, Task.Delay(timeout)))
             {
@@ -16,11 +19,14 @@ namespace Microsoft.AspNetCore.Testing
             }
             else
             {
-                throw new TimeoutException();
+                throw new TimeoutException(
+                    CreateMessage(timeout, filePath, lineNumber));
             }
         }
 
-        public static async Task TimeoutAfter(this Task task, TimeSpan timeout)
+        public static async Task TimeoutAfter(this Task task, TimeSpan timeout,
+            [CallerFilePath] string filePath = null,
+            [CallerLineNumber] int lineNumber = default(int))
         {
             if (task == await Task.WhenAny(task, Task.Delay(timeout)))
             {
@@ -28,8 +34,13 @@ namespace Microsoft.AspNetCore.Testing
             }
             else
             {
-                throw new TimeoutException();
+                throw new TimeoutException(CreateMessage(timeout, filePath, lineNumber));
             }
         }
+
+        private static string CreateMessage(TimeSpan timeout, string filePath, int lineNumber)
+            => string.IsNullOrEmpty(filePath)
+            ? $"The operation timed out after reaching the limit of {timeout.TotalMilliseconds}ms."
+            : $"The operation at {filePath}:{lineNumber} timed out after reaching the limit of {timeout.TotalMilliseconds}ms.";
     }
 }


### PR DESCRIPTION
Trying to get more information about some hung tests.