### PR TITLE
Remove invalid TargetFrameworks conditional.

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
+++ b/src/Microsoft.AspNetCore.Testing/Microsoft.AspNetCore.Testing.csproj
@@ -5,7 +5,6 @@
   <PropertyGroup>
     <Description>Various helpers for writing tests that use ASP.NET Core.</Description>
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore</PackageTags>


### PR DESCRIPTION
When we have library projects that have conditional TFMs they look different when packaged than when they're used as project references. There's no need for the Testing project (at least no reason that I know of) to have the conditional TFM.