### PR TITLE
Helpful message for missing StatusCode

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/HttpClientSlim.cs
+++ b/src/Microsoft.AspNetCore.Testing/HttpClientSlim.cs
@@ -78,6 +78,12 @@ namespace Microsoft.AspNetCore.Testing
             var statusStart = response.IndexOf(' ') + 1;
             var statusEnd = response.IndexOf(' ', statusStart) - 1;
             var statusLength = statusEnd - statusStart + 1;
+
+            if (statusLength < 1)
+            {
+                throw new InvalidDataException($"No StatusCode found in '{response}'");
+            }
+
             return (HttpStatusCode)int.Parse(response.Substring(statusStart, statusLength));
         }
 


### PR DESCRIPTION
We ran into a case where this failed, but failed when trying to substring, thus not seeing what the failed response was. If someone more familiar with the area could guess what case might cause this I can add a test.