### PR TITLE
Make SkippedTestCase and related utilities public

### DIFF
--- a/src/Microsoft.AspNetCore.Testing/xunit/SkippedTestCase.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/SkippedTestCase.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Testing.xunit
 {
-    internal class SkippedTestCase : XunitTestCase
+    public class SkippedTestCase : XunitTestCase
     {
         private string _skipReason;
 

--- a/src/Microsoft.AspNetCore.Testing/xunit/TestMethodExtensions.cs
+++ b/src/Microsoft.AspNetCore.Testing/xunit/TestMethodExtensions.cs
@@ -7,7 +7,7 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Testing.xunit
 {
-    internal static class TestMethodExtensions
+    public static class TestMethodExtensions
     {
         public static string EvaluateSkipConditions(this ITestMethod testMethod)
         {


### PR DESCRIPTION
Required to reduce duplication in https://github.com/aspnet/Logging/pull/798. 

This could also potentially reduce the duplication currently in 
https://github.com/aspnet/EntityFrameworkCore/blob/69f870ab1f32b3185c3599887fbe020c0f70c445/src/EFCore.Specification.Tests/TestUtilities/Xunit/SkippedTestCase.cs#L10
and 
https://github.com/aspnet/Performance/blob/598c2257179779c01cbd5b705572569bb5afd8b6/src/Benchmarks.Framework/SkippedTestCase.cs#L10